### PR TITLE
cargo: bump hyper-rustls to 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,20 +15,20 @@ exclude = [
 [dependencies]
 base64 = "0.9"
 error-chain = { version = "0.12", default-features = false }
-hyper = "0.11"
-hyper-rustls = "0.8"
 futures = "0.1"
-tokio-core = "0.1"
+hyper = "0.11"
+hyper-rustls = "0.12"
+libflate = "0.1"
+log = "0.3"
+# See https://github.com/lipanski/mockito/issues/19
+mockito = { version = "0.5", optional = true }
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
-log = "0.3"
 strum = "0.6"
 strum_macros = "0.6"
 tar = "0.4"
-libflate = "0.1"
-# See https://github.com/lipanski/mockito/issues/19
-mockito = { version = "0.5", optional = true }
+tokio-core = "0.1"
 
 [dev-dependencies]
 env_logger = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,7 @@ hyper = "0.11"
 hyper-rustls = "0.12"
 libflate = "0.1"
 log = "0.3"
-# See https://github.com/lipanski/mockito/issues/19
-mockito = { version = "0.5", optional = true }
+mockito = { version = "0.13", optional = true }
 serde = "1"
 serde_derive = "1"
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ conformant to the [Docker Registry HTTP API V2][registry-v2] specification.
 
 ### Integration tests
 
-This library relies on the [mockito][mockito-gh] framework for mocking. At this time, it is not multi-thread aware.
+This library relies on the [mockito][mockito-gh] framework for mocking.
 
-As such, tests should be run serially via:
+Mock tests can be enabled via the `test-mock` feature:
 ```
-cargo test --features test-mock -- --test-threads=1
+cargo test --features test-mock
 ```
 
 [mockito-gh]: https://github.com/lipanski/mockito

--- a/tests/mock/api_version.rs
+++ b/tests/mock/api_version.rs
@@ -8,20 +8,17 @@ use self::tokio_core::reactor::Core;
 static API_VERSION_K: &'static str = "Docker-Distribution-API-Version";
 static API_VERSION_V: &'static str = "registry/2.0";
 
-fn mock_version_ep() {
-    mock("GET", "/v2/")
+#[test]
+fn test_version_check_status_ok() {
+    let addr = mockito::SERVER_ADDRESS.replace("127.0.0.1", "localhost");
+    let _m = mock("GET", "/v2/")
         .with_status(200)
         .with_header(API_VERSION_K, API_VERSION_V)
         .create();
-}
-
-#[test]
-fn test_version_check_status_ok() {
-    mock_version_ep();
 
     let mut tcore = Core::new().unwrap();
     let dclient = dkregistry::v2::Client::configure(&tcore.handle())
-        .registry(mockito::SERVER_ADDRESS)
+        .registry(&addr)
         .insecure_registry(true)
         .username(None)
         .password(None)
@@ -38,14 +35,15 @@ fn test_version_check_status_ok() {
 
 #[test]
 fn test_version_check_status_unauth() {
-    mock("GET", "/v2/")
+    let addr = mockito::SERVER_ADDRESS.replace("127.0.0.1", "localhost");
+    let _m = mock("GET", "/v2/")
         .with_status(401)
         .with_header(API_VERSION_K, API_VERSION_V)
         .create();
 
     let mut tcore = Core::new().unwrap();
     let dclient = dkregistry::v2::Client::configure(&tcore.handle())
-        .registry(mockito::SERVER_ADDRESS)
+        .registry(&addr)
         .insecure_registry(true)
         .username(None)
         .password(None)
@@ -62,14 +60,15 @@ fn test_version_check_status_unauth() {
 
 #[test]
 fn test_version_check_status_notfound() {
-    mock("GET", "/v2/")
+    let addr = mockito::SERVER_ADDRESS.replace("127.0.0.1", "localhost");
+    let _m = mock("GET", "/v2/")
         .with_status(404)
         .with_header(API_VERSION_K, API_VERSION_V)
         .create();
 
     let mut tcore = Core::new().unwrap();
     let dclient = dkregistry::v2::Client::configure(&tcore.handle())
-        .registry(mockito::SERVER_ADDRESS)
+        .registry(&addr)
         .insecure_registry(true)
         .username(None)
         .password(None)
@@ -86,14 +85,15 @@ fn test_version_check_status_notfound() {
 
 #[test]
 fn test_version_check_status_forbidden() {
-    mock("GET", "/v2/")
+    let addr = mockito::SERVER_ADDRESS.replace("127.0.0.1", "localhost");
+    let _m = mock("GET", "/v2/")
         .with_status(403)
         .with_header(API_VERSION_K, API_VERSION_V)
         .create();
 
     let mut tcore = Core::new().unwrap();
     let dclient = dkregistry::v2::Client::configure(&tcore.handle())
-        .registry(mockito::SERVER_ADDRESS)
+        .registry(&addr)
         .insecure_registry(true)
         .username(None)
         .password(None)
@@ -110,13 +110,14 @@ fn test_version_check_status_forbidden() {
 
 #[test]
 fn test_version_check_noheader() {
-    mock("GET", "/v2/")
+    let addr = mockito::SERVER_ADDRESS.replace("127.0.0.1", "localhost");
+    let _m = mock("GET", "/v2/")
         .with_status(403)
         .create();
 
     let mut tcore = Core::new().unwrap();
     let dclient = dkregistry::v2::Client::configure(&tcore.handle())
-        .registry(mockito::SERVER_ADDRESS)
+        .registry(&addr)
         .insecure_registry(true)
         .username(None)
         .password(None)
@@ -133,14 +134,15 @@ fn test_version_check_noheader() {
 
 #[test]
 fn test_version_check_trailing_slash() {
-    mock("GET", "/v2")
+    let addr = mockito::SERVER_ADDRESS.replace("127.0.0.1", "localhost");
+    let _m = mock("GET", "/v2")
         .with_status(200)
         .with_header(API_VERSION_K, API_VERSION_V)
         .create();
 
     let mut tcore = Core::new().unwrap();
     let dclient = dkregistry::v2::Client::configure(&tcore.handle())
-        .registry(mockito::SERVER_ADDRESS)
+        .registry(&addr)
         .insecure_registry(true)
         .username(None)
         .password(None)

--- a/tests/mock/base_client.rs
+++ b/tests/mock/base_client.rs
@@ -8,17 +8,17 @@ use self::tokio_core::reactor::Core;
 static API_VERSION_K: &'static str = "Docker-Distribution-API-Version";
 static API_VERSION_V: &'static str = "registry/2.0";
 
-fn mock_version_ep() {
-    mock("GET", "/v2/").with_status(200).with_header(API_VERSION_K, API_VERSION_V).create();
-}
-
 #[test]
 fn test_base_no_insecure() {
-    mock_version_ep();
+    let addr = mockito::SERVER_ADDRESS.replace("127.0.0.1", "localhost");
+    let _m = mock("GET", "/v2/")
+        .with_status(200)
+        .with_header(API_VERSION_K, API_VERSION_V)
+        .create();
 
     let mut tcore = Core::new().unwrap();
     let dclient = dkregistry::v2::Client::configure(&tcore.handle())
-        .registry(mockito::SERVER_ADDRESS)
+        .registry(&addr)
         .insecure_registry(false)
         .username(None)
         .password(None)
@@ -36,7 +36,8 @@ fn test_base_no_insecure() {
 
 #[test]
 fn test_base_useragent() {
-    mock("GET", "/v2/")
+    let addr = mockito::SERVER_ADDRESS.replace("127.0.0.1", "localhost");
+    let _m = mock("GET", "/v2/")
         .match_header("user-agent", dkregistry::USER_AGENT)
         .with_status(200)
         .with_header(API_VERSION_K, API_VERSION_V)
@@ -44,7 +45,7 @@ fn test_base_useragent() {
 
     let mut tcore = Core::new().unwrap();
     let dclient = dkregistry::v2::Client::configure(&tcore.handle())
-        .registry(mockito::SERVER_ADDRESS)
+        .registry(&addr)
         .insecure_registry(true)
         .username(None)
         .password(None)
@@ -63,7 +64,8 @@ fn test_base_useragent() {
 fn test_base_custom_useragent() {
     let ua = "custom-ua/1.0";
 
-    mock("GET", "/v2/")
+    let addr = mockito::SERVER_ADDRESS.replace("127.0.0.1", "localhost");
+    let _m = mock("GET", "/v2/")
         .match_header("user-agent", ua)
         .with_status(200)
         .with_header(API_VERSION_K, API_VERSION_V)
@@ -71,7 +73,7 @@ fn test_base_custom_useragent() {
 
     let mut tcore = Core::new().unwrap();
     let dclient = dkregistry::v2::Client::configure(&tcore.handle())
-        .registry(mockito::SERVER_ADDRESS)
+        .registry(&addr)
         .insecure_registry(true)
         .user_agent(Some(ua.to_string()))
         .username(None)
@@ -89,7 +91,8 @@ fn test_base_custom_useragent() {
 
 #[test]
 fn test_base_no_useragent() {
-    mock("GET", "/v2/")
+    let addr = mockito::SERVER_ADDRESS.replace("127.0.0.1", "localhost");
+    let _m = mock("GET", "/v2/")
         .match_header("user-agent", mockito::Matcher::Missing)
         .with_status(200)
         .with_header(API_VERSION_K, API_VERSION_V)
@@ -97,7 +100,7 @@ fn test_base_no_useragent() {
 
     let mut tcore = Core::new().unwrap();
     let dclient = dkregistry::v2::Client::configure(&tcore.handle())
-        .registry(mockito::SERVER_ADDRESS)
+        .registry(&addr)
         .insecure_registry(true)
         .user_agent(None)
         .username(None)

--- a/tests/mock/blobs_download.rs
+++ b/tests/mock/blobs_download.rs
@@ -12,7 +12,8 @@ fn test_blobs_has_layer() {
     let binary_digest = "binarydigest";
 
     let ep = format!("/v2/{}/blobs/{}", name, digest);
-    mock("HEAD", ep.as_str())
+    let addr = mockito::SERVER_ADDRESS.replace("127.0.0.1", "localhost");
+    let _m = mock("HEAD", ep.as_str())
         .with_status(200)
         .with_header("Content-Length", "0")
         .with_header("Docker-Content-Digest", binary_digest)
@@ -20,7 +21,7 @@ fn test_blobs_has_layer() {
 
     let mut tcore = Core::new().unwrap();
     let dclient = dkregistry::v2::Client::configure(&tcore.handle())
-        .registry(mockito::SERVER_ADDRESS)
+        .registry(&addr)
         .insecure_registry(true)
         .username(None)
         .password(None)
@@ -41,11 +42,12 @@ fn test_blobs_hasnot_layer() {
     let digest = "fakedigest";
 
     let ep = format!("/v2/{}/blobs/{}", name, digest);
-    mock("HEAD", ep.as_str()).with_status(404).create();
+    let addr = mockito::SERVER_ADDRESS.replace("127.0.0.1", "localhost");
+    let _m = mock("HEAD", ep.as_str()).with_status(404).create();
 
     let mut tcore = Core::new().unwrap();
     let dclient = dkregistry::v2::Client::configure(&tcore.handle())
-        .registry(mockito::SERVER_ADDRESS)
+        .registry(&addr)
         .insecure_registry(true)
         .username(None)
         .password(None)

--- a/tests/mock/catalog.rs
+++ b/tests/mock/catalog.rs
@@ -12,14 +12,15 @@ fn test_catalog_simple() {
     let repos = r#"{"repositories": ["r1/i1", "r2"]}"#;
 
     let ep = format!("/v2/_catalog");
-    mock("GET", ep.as_str())
+    let addr = mockito::SERVER_ADDRESS.replace("127.0.0.1", "localhost");
+    let _m = mock("GET", ep.as_str())
         .with_status(200)
         .with_body(repos)
         .create();
 
     let mut tcore = Core::new().unwrap();
     let dclient = dkregistry::v2::Client::configure(&tcore.handle())
-        .registry(mockito::SERVER_ADDRESS)
+        .registry(&addr)
         .insecure_registry(true)
         .username(None)
         .password(None)
@@ -39,7 +40,8 @@ fn test_catalog_paginate() {
     let repos_p1 = r#"{"repositories": ["r1/i1"]}"#;
     let repos_p2 = r#"{"repositories": ["r2"]}"#;
 
-    mock("GET", "/v2/_catalog?n=1")
+    let addr = mockito::SERVER_ADDRESS.replace("127.0.0.1", "localhost");
+    let _m1 = mock("GET", "/v2/_catalog?n=1")
         .with_status(200)
         .with_header("Link",
                      &format!(r#"<{}/v2/_catalog?n=21&last=r1/i1>; rel="next""#,
@@ -47,7 +49,7 @@ fn test_catalog_paginate() {
         .with_header("Content-Type", "application/json")
         .with_body(repos_p1)
         .create();
-    mock("GET", "/v2/_catalog?n=1&last=r1")
+    let _m2 = mock("GET", "/v2/_catalog?n=1&last=r1")
         .with_status(200)
         .with_header("Content-Type", "application/json")
         .with_body(repos_p2)
@@ -55,7 +57,7 @@ fn test_catalog_paginate() {
 
     let mut tcore = Core::new().unwrap();
     let dclient = dkregistry::v2::Client::configure(&tcore.handle())
-        .registry(mockito::SERVER_ADDRESS)
+        .registry(&addr)
         .insecure_registry(true)
         .username(None)
         .password(None)

--- a/tests/mock/tags.rs
+++ b/tests/mock/tags.rs
@@ -13,7 +13,8 @@ fn test_tags_simple() {
     let tags = r#"{"name": "repo", "tags": [ "t1", "t2" ]}"#;
 
     let ep = format!("/v2/{}/tags/list", name);
-    mock("GET", ep.as_str())
+    let addr = mockito::SERVER_ADDRESS.replace("127.0.0.1", "localhost");
+    let _m = mock("GET", ep.as_str())
         .with_status(200)
         .with_header("Content-Type", "application/json")
         .with_body(tags)
@@ -21,7 +22,7 @@ fn test_tags_simple() {
 
     let mut tcore = Core::new().unwrap();
     let dclient = dkregistry::v2::Client::configure(&tcore.handle())
-        .registry(mockito::SERVER_ADDRESS)
+        .registry(&addr)
         .insecure_registry(true)
         .username(None)
         .password(None)
@@ -44,7 +45,8 @@ fn test_tags_paginate() {
 
     let ep1 = format!("/v2/{}/tags/list?n=1", name);
     let ep2 = format!("/v2/{}/tags/list?n=1&last=t1", name);
-    mock("GET", &ep1)
+    let addr = mockito::SERVER_ADDRESS.replace("127.0.0.1", "localhost");
+    let _m1 = mock("GET", ep1.as_str())
         .with_status(200)
         .with_header("Link",
                      &format!(r#"<{}/v2/_tags?n=1&last=t1>; rel="next""#,
@@ -52,7 +54,7 @@ fn test_tags_paginate() {
         .with_header("Content-Type", "application/json")
         .with_body(tags_p1)
         .create();
-    mock("GET", &ep2)
+    let _m2 = mock("GET", ep2.as_str())
         .with_status(200)
         .with_header("Content-Type", "application/json")
         .with_body(tags_p2)
@@ -60,7 +62,7 @@ fn test_tags_paginate() {
 
     let mut tcore = Core::new().unwrap();
     let dclient = dkregistry::v2::Client::configure(&tcore.handle())
-        .registry(mockito::SERVER_ADDRESS)
+        .registry(&addr)
         .insecure_registry(true)
         .username(None)
         .password(None)
@@ -86,14 +88,15 @@ fn test_tags_paginate() {
 fn test_tags_404() {
     let name = "repo";
     let ep = format!("/v2/{}/tags/list", name);
-    mock("GET", ep.as_str())
+    let addr = mockito::SERVER_ADDRESS.replace("127.0.0.1", "localhost");
+    let _m = mock("GET", ep.as_str())
         .with_status(404)
         .with_header("Content-Type", "application/json")
         .create();
 
     let mut tcore = Core::new().unwrap();
     let dclient = dkregistry::v2::Client::configure(&tcore.handle())
-        .registry(mockito::SERVER_ADDRESS)
+        .registry(&addr)
         .insecure_registry(true)
         .username(None)
         .password(None)
@@ -114,14 +117,15 @@ fn test_tags_missing_header() {
     let tags = r#"{"name": "repo", "tags": [ "t1", "t2" ]}"#;
     let ep = format!("/v2/{}/tags/list", name);
 
-    mock("GET", ep.as_str())
+    let addr = mockito::SERVER_ADDRESS.replace("127.0.0.1", "localhost");
+    let _m = mock("GET", ep.as_str())
         .with_status(200)
         .with_body(tags)
         .create();
 
     let mut tcore = Core::new().unwrap();
     let dclient = dkregistry::v2::Client::configure(&tcore.handle())
-        .registry(mockito::SERVER_ADDRESS)
+        .registry(&addr)
         .insecure_registry(true)
         .username(None)
         .password(None)


### PR DESCRIPTION
This update hyper-rustls and mockito to latest versions.