### PR TITLE
v2/tags: follow results on multiple pages

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,8 @@
 //! # }
 //! ```
 
+#![deny(missing_debug_implementations)]
+
 extern crate base64;
 extern crate futures;
 extern crate http;

--- a/src/v2/tags.rs
+++ b/src/v2/tags.rs
@@ -5,65 +5,117 @@ use v2::*;
 /// Convenience alias for a stream of `String` tags.
 pub type StreamTags = Box<futures::Stream<Item = String, Error = Error>>;
 
+/// A chunk of tags for an image.
+///
+/// This contains a non-strict subset of the whole list of tags
+/// for an image, depending on pagination option at request time.
 #[derive(Debug, Default, Deserialize, Serialize)]
-struct Tags {
+struct TagsChunk {
+    /// Image repository name.
     name: String,
+    /// Subset of tags.
     tags: Vec<String>,
 }
 
 impl Client {
     /// List existing tags for an image.
     pub fn get_tags(&self, name: &str, paginate: Option<u32>) -> StreamTags {
-        let url = {
-            let mut s = format!("{}/v2/{}/tags/list", self.base_url, name);
-            if let Some(n) = paginate {
-                s = s + &format!("?n={}", n);
+        let dclient = self.clone();
+        let base_url = format!("{}/v2/{}/tags/list", self.base_url, name);
+
+        let fres = futures::stream::unfold(Some(String::new()), move |link| {
+            // Stream ends when response has no `Link` header.
+            let last = match link {
+                None => return None,
+                Some(ref s) if s == "" => None,
+                s => s,
             };
-            match hyper::Uri::from_str(s.as_str()) {
-                Ok(url) => url,
-                Err(e) => {
-                    return Box::new(futures::stream::once(Err(format!(
-                        "failed to parse url from string: {}",
-                        e
-                    ).into())));
-                }
-            }
-        };
-        let req = match self.new_request(hyper::Method::GET, url.clone()) {
-            Ok(r) => r,
-            Err(e) => {
-                let msg = format!("new_request failed: {}", e);
-                error!("{}", msg);
-                return Box::new(futures::stream::once(Err(msg.into())));
-            }
-        };
-        let freq = self.hclient.request(req);
-        let fres = freq
-            .from_err()
-            .and_then(|r| {
-                let status = r.status();
-                if status != hyper::StatusCode::OK {
-                    return Err(format!("get_tags: wrong HTTP status '{}", status).into());
-                };
-                {
-                    let ct_hdr = r.headers().get(header::CONTENT_TYPE);
+
+            let full_url = match (paginate, last) {
+                (Some(p), None) => format!("{}?n={}", base_url, p),
+                (None, Some(l)) => format!("{}?next_page={}", base_url, l),
+                (Some(p), Some(l)) => format!("{}?n={}&next_page={}", base_url, p, l),
+                _ => base_url.to_string(),
+            };
+            let client = dclient.clone();
+            let url = hyper::Uri::from_str(&full_url);
+
+            let freq = futures::future::result(url)
+                .from_err()
+                .and_then(move |url| {
+                    trace!("GET {:?}", &url);
+                    let req = client.new_request(hyper::Method::GET, url);
+                    futures::future::result(req)
+                        .and_then(move |req| client.hclient.request(req).from_err())
+                }).and_then(|resp| {
+                    let status = resp.status();
+                    match status {
+                        hyper::StatusCode::OK => Ok(resp),
+                        _ => Err(format!("get_tags: wrong HTTP status '{}'", status).into()),
+                    }
+                }).and_then(|resp| {
+                    let ct_hdr = resp.headers().get(header::CONTENT_TYPE).cloned();
                     let ok = match ct_hdr {
                         None => false,
-                        Some(ct) => ct.to_str()?.starts_with("application/json"),
+                        Some(ref ct) => ct.to_str()?.starts_with("application/json"),
                     };
                     if !ok {
                         return Err(format!("get_tags: wrong content type '{:?}'", ct_hdr).into());
                     }
-                }
-                Ok(r)
-            }).and_then(|r| {
-                r.into_body()
-                    .concat2()
-                    .map_err(|e| format!("get_tags: failed to fetch the whole body: {}", e).into())
-            }).and_then(|body| -> Result<Tags> {
-                serde_json::from_slice(&body.into_bytes()).map_err(|e| e.into())
-            }).map(|ts| futures::stream::iter_ok(ts.tags.into_iter()))
-            .flatten_stream();
+                    Ok(resp)
+                }).and_then(|resp| {
+                    let hdr = resp.headers().get(header::LINK).cloned();
+                    trace!("next_page {:?}", hdr);
+                    resp.into_body()
+                        .concat2()
+                        .map_err(|e| {
+                            format!("get_tags: failed to fetch the whole body: {}", e).into()
+                        }).and_then(move |body| Ok((body, parse_link(hdr))))
+                }).and_then(|(body, hdr)| -> Result<(TagsChunk, Option<String>)> {
+                    serde_json::from_slice(&body.into_bytes())
+                        .map_err(|e| e.into())
+                        .map(|tags_chunk| (tags_chunk, hdr))
+                }).map(|(tags_chunk, last)| {
+                    (futures::stream::iter_ok(tags_chunk.tags.into_iter()), last)
+                });
+            Some(freq)
+        }).flatten();
+
         Box::new(fres)
+    }
+}
+
+/// Parse a `Link` header.
+///
+/// Format is described at https://docs.docker.com/registry/spec/api/#listing-image-tags#pagination.
+fn parse_link(hdr: Option<header::HeaderValue>) -> Option<String> {
+    // TODO(lucab): this a brittle string-matching parser. Investigate
+    // whether there is a a common library to do this, in the future.
+
+    // Raw Header value bytes.
+    let hval = match hdr {
+        Some(v) => v,
+        None => return None,
+    };
+
+    // Header value string.
+    let sval = match hval.to_str() {
+        Ok(v) => v.to_owned(),
+        _ => return None,
+    };
+
+    // Query parameters for next page URL.
+    let uri = sval.trim_right_matches(">; rel=\"next\"");
+    let query: Vec<&str> = uri.splitn(2, "next_page=").collect();
+    let params = match query.get(1) {
+        Some(v) if *v != "" => v,
+        _ => return None,
+    };
+
+    // Last item in current page (pagination parameter).
+    let last: Vec<&str> = params.splitn(2, '&').collect();
+    match last.get(0).cloned() {
+        Some(v) if v != "" => Some(v.to_string()),
+        _ => None,
     }
 }

--- a/tests/net/quay_io/mod.rs
+++ b/tests/net/quay_io/mod.rs
@@ -67,7 +67,7 @@ fn test_quayio_insecure() {
 }
 
 #[test]
-fn test_quayio_get_tags() {
+fn test_quayio_get_tags_simple() {
     let mut tcore = Core::new().unwrap();
     let dclient = dkregistry::v2::Client::configure(&tcore.handle())
         .registry(REGISTRY)
@@ -81,6 +81,44 @@ fn test_quayio_get_tags() {
     let fut_tags = dclient.get_tags(image, None);
     let tags = tcore.run(fut_tags.collect()).unwrap();
     let has_version = tags.iter().any(|t| t == "latest");
+
+    assert_eq!(has_version, true);
+}
+
+#[test]
+fn test_quayio_get_tags_limit() {
+    let mut tcore = Core::new().unwrap();
+    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+        .registry(REGISTRY)
+        .insecure_registry(false)
+        .username(None)
+        .password(None)
+        .build()
+        .unwrap();
+
+    let image = "coreos/alpine-sh";
+    let fut_tags = dclient.get_tags(image, Some(10));
+    let tags = tcore.run(fut_tags.collect()).unwrap();
+    let has_version = tags.iter().any(|t| t == "latest");
+
+    assert_eq!(has_version, true);
+}
+
+#[test]
+fn test_quayio_get_tags_pagination() {
+    let mut tcore = Core::new().unwrap();
+    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+        .registry(REGISTRY)
+        .insecure_registry(false)
+        .username(None)
+        .password(None)
+        .build()
+        .unwrap();
+
+    let image = "coreos/flannel";
+    let fut_tags = dclient.get_tags(image, Some(20));
+    let tags = tcore.run(fut_tags.collect()).unwrap();
+    let has_version = tags.iter().any(|t| t == "v0.10.0");
 
     assert_eq!(has_version, true);
 }


### PR DESCRIPTION
This adds full support for tags pagination, with per-page limit
and next page following.