### PR TITLE
API: substitute `Result<Future..>` with `Future..` for more idiomatic future chaining

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ strum = "0.11"
 strum_macros = "0.11"
 tar = "0.4"
 tokio-core = "0.1"
+dirs = "1.0"
 
 [dev-dependencies]
 env_logger = "0.5"

--- a/examples/checkregistry.rs
+++ b/examples/checkregistry.rs
@@ -4,8 +4,6 @@ extern crate tokio_core;
 use std::{boxed, error};
 use tokio_core::reactor::Core;
 
-type Result<T> = std::result::Result<T, boxed::Box<error::Error>>;
-
 fn main() {
     let registry = match std::env::args().nth(1) {
         Some(x) => x,
@@ -20,7 +18,7 @@ fn main() {
     };
 }
 
-fn run(host: &str) -> Result<bool> {
+fn run(host: &str) -> Result<bool, boxed::Box<error::Error>> {
     let mut tcore = try!(Core::new());
     let dclient = try!(
         dkregistry::v2::Client::configure(&tcore.handle())
@@ -28,12 +26,12 @@ fn run(host: &str) -> Result<bool> {
             .insecure_registry(false)
             .build()
     );
-    let futcheck = try!(dclient.is_v2_supported());
+    let futcheck = dclient.is_v2_supported();
 
     let supported = try!(tcore.run(futcheck));
     match supported {
         false => println!("{} does NOT support v2", host),
         true => println!("{} supports v2", host),
     }
-    return Ok(supported);
+    Ok(supported)
 }

--- a/examples/common/mod.rs
+++ b/examples/common/mod.rs
@@ -1,0 +1,42 @@
+extern crate dkregistry;
+extern crate futures;
+
+use futures::prelude::*;
+
+pub fn authenticate_client<'a>(
+    client: &'a mut dkregistry::v2::Client,
+    login_scope: &'a str,
+) -> impl futures::future::Future<Item = &'a dkregistry::v2::Client, Error = dkregistry::errors::Error>
+{
+    futures::future::ok::<_, dkregistry::errors::Error>(client)
+        .and_then(|dclient| {
+            dclient.is_v2_supported().and_then(|v2_supported| {
+                if !v2_supported {
+                    Err("API v2 not supported".into())
+                } else {
+                    Ok(dclient)
+                }
+            })
+        }).and_then(|dclient| {
+            dclient.is_auth(None).and_then(|is_auth| {
+                if is_auth {
+                    Err("no login performed, but already authenticated".into())
+                } else {
+                    Ok(dclient)
+                }
+            })
+        }).and_then(move |dclient| {
+            dclient.login(&[&login_scope]).and_then(move |token| {
+                dclient
+                    .is_auth(Some(token.token()))
+                    .and_then(move |is_auth| {
+                        if !is_auth {
+                            Err("login failed".into())
+                        } else {
+                            println!("logged in!");
+                            Ok(dclient.set_token(Some(token.token())))
+                        }
+                    })
+            })
+        })
+}

--- a/examples/tags.rs
+++ b/examples/tags.rs
@@ -55,13 +55,16 @@ fn run(
     let login_scope = format!("repository:{}:pull", image);
 
     let futures = common::authenticate_client(&mut client, &login_scope)
-        .and_then(|dclient| dclient.get_tags(&image, Some(7)).collect());
+        .and_then(|dclient| dclient.get_tags(&image, Some(7)).collect())
+        .and_then(|tags| {
+            for tag in tags {
+                println!("{:?}", tag);
+            }
+            Ok(())
+        });
 
     match tcore.run(futures) {
-        Ok(tags) => {
-            println!("{:?}", tags);
-            Ok(())
-        }
+        Ok(_) => Ok(()),
         Err(e) => Err(Box::new(e)),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //!                      .insecure_registry(false)
 //!                      .registry(host)
 //!                      .build()?;
-//! let check = dclient.is_v2_supported()?;
+//! let check = dclient.is_v2_supported();
 //! match tcore.run(check)? {
 //!     false => println!("{} does NOT support v2", host),
 //!     true => println!("{} supports v2", host),

--- a/src/mediatypes.rs
+++ b/src/mediatypes.rs
@@ -65,16 +65,16 @@ impl MediaTypes {
             _ => bail!("unknown mediatype {:?}", mtype),
         }
     }
-    pub fn to_mime(&self) -> mime::Mime {
+    pub fn to_mime(&self) -> Result<mime::Mime> {
         match self {
-            &MediaTypes::ApplicationJson => mime::APPLICATION_JSON,
+            &MediaTypes::ApplicationJson => Ok(mime::APPLICATION_JSON),
             ref m => {
                 if let Some(s) = m.get_str("Sub") {
-                    ("application/".to_string() + s).parse().unwrap()
+                    ("application/".to_string() + s).parse()
                 } else {
-                    "application/star".parse().unwrap()
+                    "application/star".parse()
                 }
             }
-        }
+        }.map_err(|e| Error::from(e.to_string()))
     }
 }

--- a/src/v2/blobs.rs
+++ b/src/v2/blobs.rs
@@ -21,7 +21,14 @@ impl Client {
                 }
             }
         };
-        let req = self.new_request(hyper::Method::HEAD, url.clone());
+        let req = match self.new_request(hyper::Method::HEAD, url.clone()) {
+            Ok(r) => r,
+            Err(e) => {
+                let msg = format!("new_request failed: {}", e);
+                error!("{}", msg);
+                return Box::new(futures::future::err::<_, _>(Error::from(msg)));
+            }
+        };
         let freq = self.hclient.request(req);
         let fres = freq
             .from_err()
@@ -51,11 +58,18 @@ impl Client {
                     return Box::new(futures::future::err::<_, _>(Error::from(format!(
                         "failed to parse url from string: {}",
                         e
-                    ))))
+                    ))));
                 }
             }
         };
-        let req = self.new_request(hyper::Method::GET, url.clone());
+        let req = match self.new_request(hyper::Method::GET, url.clone()) {
+            Ok(r) => r,
+            Err(e) => {
+                let msg = format!("new_request failed: {}", e);
+                error!("{}", msg);
+                return Box::new(futures::future::err::<_, _>(Error::from(msg)));
+            }
+        };
         let freq = self.hclient.request(req);
         let fres = freq
             .from_err()

--- a/src/v2/manifest/mod.rs
+++ b/src/v2/manifest/mod.rs
@@ -18,18 +18,20 @@ impl Client {
     ///
     /// The name and reference parameters identify the image.
     /// The reference may be either a tag or digest.
-    pub fn get_manifest(&self, name: &str, reference: &str) -> Result<FutureManifest> {
-        let url = try!(hyper::Uri::from_str(&format!(
+    pub fn get_manifest(&self, name: &str, reference: &str) -> FutureManifest {
+        let url = hyper::Uri::from_str(&format!(
             "{}/v2/{}/manifests/{}",
             self.base_url.clone(),
             name,
             reference
-        )));
+        )).unwrap();
         let req = {
             let mut r = self.new_request(hyper::Method::GET, url.clone());
             let mtype = mediatypes::MediaTypes::ManifestV2S2.to_string();
-            r.headers_mut()
-                .append(header::ACCEPT, header::HeaderValue::from_str(&mtype)?);
+            r.headers_mut().append(
+                header::ACCEPT,
+                header::HeaderValue::from_str(&mtype).unwrap(),
+            );
             r
         };
         let freq = self.hclient.request(req);
@@ -49,7 +51,7 @@ impl Client {
                     format!("get_manifest: failed to fetch the whole body: {}", e).into()
                 })
             }).and_then(|body| Ok(body.into_bytes().to_vec()));
-        Ok(Box::new(fres))
+        Box::new(fres)
     }
 
     /// Check if an image manifest exists.
@@ -61,7 +63,7 @@ impl Client {
         name: &str,
         reference: &str,
         mediatypes: Option<&[&str]>,
-    ) -> Result<mediatypes::FutureMediaType> {
+    ) -> mediatypes::FutureMediaType {
         let url = {
             let ep = format!(
                 "{}/v2/{}/manifests/{}",
@@ -69,11 +71,11 @@ impl Client {
                 name,
                 reference
             );
-            try!(hyper::Uri::from_str(ep.as_str()))
+            hyper::Uri::from_str(ep.as_str()).unwrap()
         };
         let accept_types = match mediatypes {
             None => vec![mediatypes::MediaTypes::ManifestV2S2.to_mime()],
-            Some(ref v) => try!(to_mimes(v)),
+            Some(ref v) => to_mimes(v).unwrap(),
         };
         let req = {
             let mut r = self.new_request(hyper::Method::HEAD, url.clone());
@@ -107,7 +109,7 @@ impl Client {
                 };
                 Ok(res)
             });
-        Ok(Box::new(fres))
+        Box::new(fres)
     }
 }
 

--- a/src/v2/tags.rs
+++ b/src/v2/tags.rs
@@ -13,13 +13,13 @@ struct Tags {
 
 impl Client {
     /// List existing tags for an image.
-    pub fn get_tags(&self, name: &str, paginate: Option<u32>) -> Result<StreamTags> {
+    pub fn get_tags(&self, name: &str, paginate: Option<u32>) -> StreamTags {
         let url = {
             let mut s = format!("{}/v2/{}/tags/list", self.base_url, name);
             if let Some(n) = paginate {
                 s = s + &format!("?n={}", n);
             };
-            try!(hyper::Uri::from_str(s.as_str()))
+            hyper::Uri::from_str(s.as_str()).unwrap()
         };
         let req = self.new_request(hyper::Method::GET, url);
         let freq = self.hclient.request(req);
@@ -49,6 +49,6 @@ impl Client {
                 serde_json::from_slice(&body.into_bytes()).map_err(|e| e.into())
             }).map(|ts| futures::stream::iter_ok(ts.tags.into_iter()))
             .flatten_stream();
-        Ok(Box::new(fres))
+        Box::new(fres)
     }
 }

--- a/tests/mock/api_version.rs
+++ b/tests/mock/api_version.rs
@@ -25,7 +25,7 @@ fn test_version_check_status_ok() {
         .build()
         .unwrap();
 
-    let futcheck = dclient.is_v2_supported().unwrap();
+    let futcheck = dclient.is_v2_supported();
 
     let res = tcore.run(futcheck).unwrap();
     assert_eq!(res, true);
@@ -50,7 +50,7 @@ fn test_version_check_status_unauth() {
         .build()
         .unwrap();
 
-    let futcheck = dclient.is_v2_supported().unwrap();
+    let futcheck = dclient.is_v2_supported();
 
     let res = tcore.run(futcheck).unwrap();
     assert_eq!(res, true);
@@ -75,7 +75,7 @@ fn test_version_check_status_notfound() {
         .build()
         .unwrap();
 
-    let futcheck = dclient.is_v2_supported().unwrap();
+    let futcheck = dclient.is_v2_supported();
 
     let res = tcore.run(futcheck).unwrap();
     assert_eq!(res, false);
@@ -100,7 +100,7 @@ fn test_version_check_status_forbidden() {
         .build()
         .unwrap();
 
-    let futcheck = dclient.is_v2_supported().unwrap();
+    let futcheck = dclient.is_v2_supported();
 
     let res = tcore.run(futcheck).unwrap();
     assert_eq!(res, false);
@@ -122,7 +122,7 @@ fn test_version_check_noheader() {
         .build()
         .unwrap();
 
-    let futcheck = dclient.is_v2_supported().unwrap();
+    let futcheck = dclient.is_v2_supported();
 
     let res = tcore.run(futcheck).unwrap();
     assert_eq!(res, false);
@@ -147,7 +147,7 @@ fn test_version_check_trailing_slash() {
         .build()
         .unwrap();
 
-    let futcheck = dclient.is_v2_supported().unwrap();
+    let futcheck = dclient.is_v2_supported();
 
     let res = tcore.run(futcheck).unwrap();
     assert_eq!(res, false);

--- a/tests/mock/base_client.rs
+++ b/tests/mock/base_client.rs
@@ -25,7 +25,7 @@ fn test_base_no_insecure() {
         .build()
         .unwrap();
 
-    let futcheck = dclient.is_v2_supported().unwrap();
+    let futcheck = dclient.is_v2_supported();
 
     // This relies on the fact that mockito is HTTP-only and
     // trying to speak TLS to it results in garbage/errors.
@@ -52,7 +52,7 @@ fn test_base_useragent() {
         .build()
         .unwrap();
 
-    let futcheck = dclient.is_v2_supported().unwrap();
+    let futcheck = dclient.is_v2_supported();
 
     let res = tcore.run(futcheck).unwrap();
     assert_eq!(res, true);
@@ -81,7 +81,7 @@ fn test_base_custom_useragent() {
         .build()
         .unwrap();
 
-    let futcheck = dclient.is_v2_supported().unwrap();
+    let futcheck = dclient.is_v2_supported();
 
     let res = tcore.run(futcheck).unwrap();
     assert_eq!(res, true);
@@ -108,7 +108,7 @@ fn test_base_no_useragent() {
         .build()
         .unwrap();
 
-    let futcheck = dclient.is_v2_supported().unwrap();
+    let futcheck = dclient.is_v2_supported();
 
     let res = tcore.run(futcheck).unwrap();
     assert_eq!(res, true);

--- a/tests/mock/blobs_download.rs
+++ b/tests/mock/blobs_download.rs
@@ -28,7 +28,7 @@ fn test_blobs_has_layer() {
         .build()
         .unwrap();
 
-    let futcheck = dclient.has_blob(name, digest).unwrap();
+    let futcheck = dclient.has_blob(name, digest);
 
     let res = tcore.run(futcheck).unwrap();
     assert_eq!(res, true);
@@ -54,7 +54,7 @@ fn test_blobs_hasnot_layer() {
         .build()
         .unwrap();
 
-    let futcheck = dclient.has_blob(name, digest).unwrap();
+    let futcheck = dclient.has_blob(name, digest);
 
     let res = tcore.run(futcheck).unwrap();
     assert_eq!(res, false);

--- a/tests/mock/catalog.rs
+++ b/tests/mock/catalog.rs
@@ -27,7 +27,7 @@ fn test_catalog_simple() {
         .build()
         .unwrap();
 
-    let futcheck = dclient.get_catalog(None).unwrap();
+    let futcheck = dclient.get_catalog(None);
 
     let res = tcore.run(futcheck.collect()).unwrap();
     assert_eq!(res, vec!["r1/i1", "r2"]);
@@ -67,7 +67,7 @@ fn test_catalog_paginate() {
         .build()
         .unwrap();
 
-    let next = dclient.get_catalog(Some(1)).unwrap();
+    let next = dclient.get_catalog(Some(1));
 
     let (page1, next) = tcore.run(next.into_future()).ok().unwrap();
     assert_eq!(page1, Some("r1/i1".to_owned()));

--- a/tests/mock/tags.rs
+++ b/tests/mock/tags.rs
@@ -29,7 +29,7 @@ fn test_tags_simple() {
         .build()
         .unwrap();
 
-    let futcheck = dclient.get_tags(name, None).unwrap();
+    let futcheck = dclient.get_tags(name, None);
 
     let res = tcore.run(futcheck.collect()).unwrap();
     assert_eq!(res, vec!["t1", "t2"]);
@@ -72,7 +72,7 @@ fn test_tags_paginate() {
         .build()
         .unwrap();
 
-    let next = dclient.get_tags(name, Some(1)).unwrap();
+    let next = dclient.get_tags(name, Some(1));
 
     let (page1, next) = tcore.run(next.into_future()).ok().unwrap();
     assert_eq!(page1, Some("t1".to_owned()));
@@ -106,7 +106,7 @@ fn test_tags_404() {
         .build()
         .unwrap();
 
-    let futcheck = dclient.get_tags(name, None).unwrap();
+    let futcheck = dclient.get_tags(name, None);
 
     let res = tcore.run(futcheck.collect());
     assert!(res.is_err());
@@ -135,7 +135,7 @@ fn test_tags_missing_header() {
         .build()
         .unwrap();
 
-    let futcheck = dclient.get_tags(name, None).unwrap();
+    let futcheck = dclient.get_tags(name, None);
 
     let res = tcore.run(futcheck.collect());
     assert!(res.is_err());

--- a/tests/net/docker_io/mod.rs
+++ b/tests/net/docker_io/mod.rs
@@ -40,7 +40,7 @@ fn test_dockerio_base() {
         .build()
         .unwrap();
 
-    let futcheck = dclient.is_v2_supported().unwrap();
+    let futcheck = dclient.is_v2_supported();
 
     let res = tcore.run(futcheck).unwrap();
     assert_eq!(res, true);
@@ -57,7 +57,7 @@ fn test_dockerio_insecure() {
         .build()
         .unwrap();
 
-    let futcheck = dclient.is_v2_supported().unwrap();
+    let futcheck = dclient.is_v2_supported();
 
     let res = tcore.run(futcheck).unwrap();
     assert_eq!(res, false);

--- a/tests/net/gcr_io/mod.rs
+++ b/tests/net/gcr_io/mod.rs
@@ -42,7 +42,7 @@ fn test_gcrio_base() {
         .build()
         .unwrap();
 
-    let futcheck = dclient.is_v2_supported().unwrap();
+    let futcheck = dclient.is_v2_supported();
 
     let res = tcore.run(futcheck).unwrap();
     assert_eq!(res, true);
@@ -59,7 +59,7 @@ fn test_gcrio_insecure() {
         .build()
         .unwrap();
 
-    let futcheck = dclient.is_v2_supported().unwrap();
+    let futcheck = dclient.is_v2_supported();
 
     let res = tcore.run(futcheck).unwrap();
     assert_eq!(res, false);
@@ -77,7 +77,7 @@ fn test_gcrio_get_tags() {
         .unwrap();
 
     let image = "google_containers/mounttest";
-    let fut_tags = dclient.get_tags(image, None).unwrap();
+    let fut_tags = dclient.get_tags(image, None);
     let tags = tcore.run(fut_tags.collect()).unwrap();
     let has_version = tags.iter().any(|t| t == "0.2");
 
@@ -98,9 +98,7 @@ fn test_gcrio_has_manifest() {
     let image = "google_containers/mounttest";
     let tag = "0.2";
     let manifest_type = dkregistry::mediatypes::MediaTypes::ManifestV2S1Signed.to_string();
-    let fut = dclient
-        .has_manifest(image, tag, Some(vec![manifest_type.as_str()].as_slice()))
-        .unwrap();
+    let fut = dclient.has_manifest(image, tag, Some(vec![manifest_type.as_str()].as_slice()));
     let has_manifest = tcore.run(fut).unwrap();
 
     assert_eq!(

--- a/tests/net/quay_io/mod.rs
+++ b/tests/net/quay_io/mod.rs
@@ -43,7 +43,7 @@ fn test_quayio_base() {
         .build()
         .unwrap();
 
-    let futcheck = dclient.is_v2_supported().unwrap();
+    let futcheck = dclient.is_v2_supported();
 
     let res = tcore.run(futcheck).unwrap();
     assert_eq!(res, true);
@@ -60,7 +60,7 @@ fn test_quayio_insecure() {
         .build()
         .unwrap();
 
-    let futcheck = dclient.is_v2_supported().unwrap();
+    let futcheck = dclient.is_v2_supported();
 
     let res = tcore.run(futcheck).unwrap();
     assert_eq!(res, false);
@@ -78,7 +78,7 @@ fn test_quayio_get_tags() {
         .unwrap();
 
     let image = "coreos/alpine-sh";
-    let fut_tags = dclient.get_tags(image, None).unwrap();
+    let fut_tags = dclient.get_tags(image, None);
     let tags = tcore.run(fut_tags.collect()).unwrap();
     let has_version = tags.iter().any(|t| t == "latest");
 
@@ -98,7 +98,7 @@ fn test_quayio_has_manifest() {
 
     let image = "coreos/alpine-sh";
     let reference = "latest";
-    let fut = dclient.has_manifest(image, reference, None).unwrap();
+    let fut = dclient.has_manifest(image, reference, None);
     let has_manifest = tcore.run(fut).unwrap();
 
     assert_eq!(has_manifest, Some(MediaTypes::ManifestV2S1Signed));
@@ -117,7 +117,7 @@ fn test_quayio_has_no_manifest() {
 
     let image = "coreos/alpine-sh";
     let reference = "clearly_bogus";
-    let fut = dclient.has_manifest(image, reference, None).unwrap();
+    let fut = dclient.has_manifest(image, reference, None);
     let has_manifest = tcore.run(fut).unwrap();
 
     assert_eq!(has_manifest, None);


### PR DESCRIPTION
This change is motivated by an out-of-band discussion with @lucab and a comment on a related PR https://github.com/openshift/cincinnati/pull/4#discussion_r225639618 by @crawford, suggesting to use future chaining.

Before this PR all methods return a `Result<Future..>` chaining them requires to `unwrap()` or slightly milder `unwrap_or_else()` for *every* additional chain element, which adds significant boilerplate for the consumer. This PR aims to aid with this by removing the outer `Result<Future..>` and return `Future..` for all async public methods.

I'd like to discuss this API breaking change with the intention to move forward with this or a similar approach for the whole crate. I've done a rewrite of the login example demonstrates the usage of the changed API.

---
- [x] Rewrite *all of the* examples to use the new API
- Rewrite examples to use chaining
  - [x] ~~examples/checkregistry.rs~~
  - [x] examples/image.rs
  - [x] examples/login.rs
  - [x] examples/tags.rs
  - [x] examples/trace.rs
- [x] Rewrite *all of the?* API


