### PR TITLE
Release 0.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dkregistry"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Luca Bruno <lucab@debian.org>"]
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/dkregistry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dkregistry"
-version = "0.2.1"
+version = "0.2.2-alpha.0"
 authors = ["Luca Bruno <lucab@debian.org>"]
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/dkregistry"


### PR DESCRIPTION
Bump version to 0.2.0 manually in order to use `cargo release patch` for a semi-automatic release.

@lucab do you usually edit the commit message generated by `cargo release`?

Depends on #52.