### PR TITLE
examples/image-labels: remove unused imports

### DIFF
--- a/examples/image-labels.rs
+++ b/examples/image-labels.rs
@@ -4,11 +4,11 @@ extern crate futures;
 extern crate serde_json;
 extern crate tokio_core;
 
-use dkregistry::{reference, render};
+use dkregistry::reference;
 use futures::prelude::*;
 use std::result::Result;
 use std::str::FromStr;
-use std::{boxed, env, error, fs, io};
+use std::{env, fs, io};
 use tokio_core::reactor::Core;
 
 mod common;


### PR DESCRIPTION
Minor cleanup of compiler warnings in examples.