### PR TITLE
blobs: return an error on unhandled http status code

### DIFF
--- a/src/v2/blobs.rs
+++ b/src/v2/blobs.rs
@@ -82,7 +82,14 @@ impl Client {
                     | StatusCode::FOUND => {
                         trace!("Got moved status {:?}", r.status());
                     }
-                    _ => return Either::A(future::ok(r)),
+                    StatusCode::OK => {
+                        return Either::A(future::ok(r));
+                    }
+                    _ => {
+                        return Either::A(future::err(
+                            format!("unexpected status code '{}'", r.status()).into(),
+                        ));
+                    }
                 };
                 let redirect: Option<String> = match r.headers().get("Location") {
                     None => {


### PR DESCRIPTION
Before this change even error codes would be treated as success and the
body would contain the HTML formatted error message passed through to
the caller.