### PR TITLE
blobs: switch from hyper to reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ strum_macros = "0.11"
 tar = "0.4"
 tokio-core = "0.1"
 dirs = "1.0"
+reqwest = "0.9"
 
 [dev-dependencies]
 env_logger = "0.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ extern crate strum;
 extern crate tar;
 #[macro_use]
 extern crate strum_macros;
+extern crate reqwest;
 
 pub mod errors;
 pub mod mediatypes;

--- a/src/v2/blobs.rs
+++ b/src/v2/blobs.rs
@@ -1,6 +1,6 @@
-use futures::future::{self, Either};
 use futures::Stream;
-use hyper::StatusCode;
+use reqwest;
+use reqwest::StatusCode;
 use v2::*;
 
 /// Convenience alias for future binary blob.
@@ -11,48 +11,7 @@ impl Client {
     pub fn has_blob(&self, name: &str, digest: &str) -> FutureBool {
         let url = {
             let ep = format!("{}/v2/{}/blobs/{}", self.base_url, name, digest);
-            match hyper::Uri::from_str(ep.as_str()) {
-                Ok(url) => url,
-                Err(e) => {
-                    return Box::new(futures::future::err::<_, _>(Error::from(format!(
-                        "failed to parse url from string: {}",
-                        e
-                    ))))
-                }
-            }
-        };
-        let req = match self.new_request(hyper::Method::HEAD, url.clone()) {
-            Ok(r) => r,
-            Err(e) => {
-                let msg = format!("new_request failed: {}", e);
-                error!("{}", msg);
-                return Box::new(futures::future::err::<_, _>(Error::from(msg)));
-            }
-        };
-        let freq = self.hclient.request(req);
-        let fres = freq
-            .from_err()
-            .inspect(move |_| {
-                trace!("HEAD {:?}", url);
-            }).and_then(|r| {
-                trace!("Blob check result: {:?}", r.status());
-                match r.status() {
-                    StatusCode::MOVED_PERMANENTLY
-                    | StatusCode::TEMPORARY_REDIRECT
-                    | StatusCode::FOUND
-                    | StatusCode::OK => Ok(true),
-                    _ => Ok(false),
-                }
-            });
-        Box::new(fres)
-    }
-
-    /// Retrieve blob.
-    pub fn get_blob(&self, name: &str, digest: &str) -> FutureBlob {
-        let cl = self.clone();
-        let url = {
-            let ep = format!("{}/v2/{}/blobs/{}", self.base_url.clone(), name, digest);
-            match hyper::Uri::from_str(ep.as_str()) {
+            match reqwest::Url::parse(&ep) {
                 Ok(url) => url,
                 Err(e) => {
                     return Box::new(futures::future::err::<_, _>(Error::from(format!(
@@ -62,60 +21,53 @@ impl Client {
                 }
             }
         };
-        let req = match self.new_request(hyper::Method::GET, url.clone()) {
-            Ok(r) => r,
-            Err(e) => {
-                let msg = format!("new_request failed: {}", e);
-                error!("{}", msg);
-                return Box::new(futures::future::err::<_, _>(Error::from(msg)));
+
+        let fres = reqwest::async::Client::new()
+            .head(url)
+            .send()
+            .inspect(|res| trace!("Blob HEAD status: {:?}", res.status()))
+            .and_then(|res| match res.status() {
+                StatusCode::OK => Ok(true),
+                _ => Ok(false),
+            }).map_err(|e| format!("{}", e).into());
+        Box::new(fres)
+    }
+
+    /// Retrieve blob.
+    pub fn get_blob(&self, name: &str, digest: &str) -> FutureBlob {
+        let url = {
+            let ep = format!("{}/v2/{}/blobs/{}", self.base_url, name, digest);
+            match reqwest::Url::parse(&ep) {
+                Ok(url) => url,
+                Err(e) => {
+                    return Box::new(futures::future::err::<_, _>(Error::from(format!(
+                        "failed to parse url from string: {}",
+                        e
+                    ))));
+                }
             }
         };
-        let freq = self.hclient.request(req);
-        let fres = freq
-            .from_err()
-            .inspect(move |_| {
-                trace!("GET {:?}", url);
-            }).and_then(move |r| {
-                match r.status() {
-                    StatusCode::MOVED_PERMANENTLY
-                    | StatusCode::TEMPORARY_REDIRECT
-                    | StatusCode::FOUND => {
-                        trace!("Got moved status {:?}", r.status());
+
+        let fres = reqwest::async::Client::new()
+            .get(url)
+            .send()
+            .inspect(|res| trace!("Blob GET status: {:?}", res.status()))
+            .and_then(|mut res| {
+                let body = std::mem::replace(res.body_mut(), reqwest::async::Decoder::empty());
+                body.concat2()
+            }).map_err(|e| Error::from(format!("{}", e)))
+            .and_then(|body| {
+                let mut cursor = std::io::Cursor::new(body);
+                let mut buf = Vec::new();
+                use std::io::Read;
+                match cursor.read_to_end(&mut buf) {
+                    Ok(size) => {
+                        trace!("Received {} bytes from blob", size);
+                        Ok(buf)
                     }
-                    _ => return Either::A(future::ok(r)),
-                };
-                let redirect: Option<String> = match r.headers().get("Location") {
-                    None => {
-                        return Either::A(future::err(Error::from(
-                            "get_blob: missing location header",
-                        )))
-                    }
-                    Some(loc) => {
-                        trace!("Got Location header {:?}", loc);
-                        String::from_utf8(loc.as_bytes().to_vec()).ok()
-                    }
-                };
-                if let Some(u) = redirect {
-                    let new_url = match hyper::Uri::from_str(u.as_str()) {
-                        Ok(u) => u,
-                        _ => {
-                            return Either::A(future::err(
-                                format!("get_blob: wrong URL '{}'", u).into(),
-                            ))
-                        }
-                    };
-                    trace!("Following redirection to {}", new_url);
-                    let mut req = hyper::Request::default();
-                    *req.method_mut() = hyper::Method::GET;
-                    *req.uri_mut() = new_url;
-                    return Either::B(cl.hclient.request(req).from_err());
-                };
-                Either::A(future::ok(r))
-            }).and_then(|r| {
-                r.into_body()
-                    .concat2()
-                    .map_err(|e| format!("get_blob: failed to fetch the whole body: {}", e).into())
-            }).and_then(|body| Ok(body.into_bytes().to_vec()));
+                    Err(e) => Err(Error::from(format!("{}", e))),
+                }
+            });
         Box::new(fres)
     }
 }


### PR DESCRIPTION
This change is motivated by improved status error handling.
Before this change even error codes would be treated as success and the
body would contain the HTML formatted error message passed through to
the caller.
Instead of reimplementing proper error handling here we can make use of
the reqwest library which already does it.

---

Closes #63 
Progress on #44