### PR TITLE
Reuse the token set by hyper for reqwest calls

### DIFF
--- a/src/v2/blobs.rs
+++ b/src/v2/blobs.rs
@@ -22,8 +22,8 @@ impl Client {
             }
         };
 
-        let fres = reqwest::async::Client::new()
-            .head(url)
+        let fres = self
+            .build_reqwest(reqwest::async::Client::new().head(url))
             .send()
             .inspect(|res| trace!("Blob HEAD status: {:?}", res.status()))
             .and_then(|res| match res.status() {
@@ -48,8 +48,7 @@ impl Client {
             }
         };
 
-        let fres = reqwest::async::Client::new()
-            .get(url)
+        let fres = self.build_reqwest(reqwest::async::Client::new().get(url))
             .send()
             .map_err(|e| ::errors::Error::from(format!("{}", e)))
             .and_then(|res| {

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -140,6 +140,18 @@ impl Client {
             });
         Box::new(fres)
     }
+
+    /// Takes reqwest's async RequestBuilder and injects an authentication header if a token is present
+    fn build_reqwest(
+        &self,
+        client: reqwest::async::RequestBuilder,
+    ) -> reqwest::async::RequestBuilder {
+        if let Some(token) = &self.token {
+            client.header(reqwest::header::AUTHORIZATION, format!("Bearer {}", token))
+        } else {
+            client
+        }
+    }
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]


### PR DESCRIPTION
Depends on #69.
Fixes #66 