### PR TITLE
dkregistry: remove tokio-core, use tokio instead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = "1"
 strum = "0.13"
 strum_macros = "0.13"
 tar = "0.4"
-tokio-core = "0.1"
+tokio = "0.1"
 dirs = "1.0"
 reqwest = "0.9"
 

--- a/examples/checkregistry.rs
+++ b/examples/checkregistry.rs
@@ -20,7 +20,7 @@ fn main() {
 
 fn run(host: &str) -> Result<bool, boxed::Box<error::Error>> {
     let mut tcore = try!(Core::new());
-    let dclient = try!(dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = try!(dkregistry::v2::Client::configure()
         .registry(host)
         .insecure_registry(false)
         .build());

--- a/examples/checkregistry.rs
+++ b/examples/checkregistry.rs
@@ -1,8 +1,8 @@
 extern crate dkregistry;
-extern crate tokio_core;
+extern crate tokio;
 
 use std::{boxed, error};
-use tokio_core::reactor::Core;
+use tokio::runtime::current_thread::Runtime;
 
 fn main() {
     let registry = match std::env::args().nth(1) {
@@ -19,14 +19,14 @@ fn main() {
 }
 
 fn run(host: &str) -> Result<bool, boxed::Box<error::Error>> {
-    let mut tcore = try!(Core::new());
+    let mut runtime = Runtime::new()?;
     let dclient = try!(dkregistry::v2::Client::configure()
         .registry(host)
         .insecure_registry(false)
         .build());
     let futcheck = dclient.is_v2_supported();
 
-    let supported = try!(tcore.run(futcheck));
+    let supported = runtime.block_on(futcheck)?;
     match supported {
         false => println!("{} does NOT support v2", host),
         true => println!("{} supports v2", host),

--- a/examples/image-labels.rs
+++ b/examples/image-labels.rs
@@ -2,14 +2,14 @@ extern crate dirs;
 extern crate dkregistry;
 extern crate futures;
 extern crate serde_json;
-extern crate tokio_core;
+extern crate tokio;
 
 use dkregistry::reference;
 use futures::prelude::*;
 use std::result::Result;
 use std::str::FromStr;
 use std::{env, fs, io};
-use tokio_core::reactor::Core;
+use tokio::runtime::current_thread::Runtime;
 
 mod common;
 
@@ -59,7 +59,7 @@ fn run(
     user: Option<String>,
     passwd: Option<String>,
 ) -> Result<(), dkregistry::errors::Error> {
-    let mut tcore = Core::new()?;
+    let mut runtime = Runtime::new()?;
 
     let mut client = dkregistry::v2::Client::configure()
         .registry(&dkr_ref.registry())
@@ -107,7 +107,7 @@ fn run(
                 })
         });
 
-    let manifest = match tcore.run(futures) {
+    let manifest = match runtime.block_on(futures) {
         Ok(manifest) => Ok(manifest),
         Err(e) => Err(format!("Got error {}", e)),
     }?;

--- a/examples/image-labels.rs
+++ b/examples/image-labels.rs
@@ -61,7 +61,7 @@ fn run(
 ) -> Result<(), dkregistry::errors::Error> {
     let mut tcore = Core::new()?;
 
-    let mut client = dkregistry::v2::Client::configure(&tcore.handle())
+    let mut client = dkregistry::v2::Client::configure()
         .registry(&dkr_ref.registry())
         .insecure_registry(false)
         .username(user)

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -61,7 +61,7 @@ fn run(
 ) -> Result<(), boxed::Box<error::Error>> {
     let mut tcore = try!(Core::new());
 
-    let mut client = dkregistry::v2::Client::configure(&tcore.handle())
+    let mut client = dkregistry::v2::Client::configure()
         .registry(&dkr_ref.registry())
         .insecure_registry(false)
         .username(user)

--- a/examples/login.rs
+++ b/examples/login.rs
@@ -1,13 +1,13 @@
 extern crate dkregistry;
 extern crate futures;
-extern crate tokio_core;
+extern crate tokio;
 
 mod common;
 
 use futures::prelude::*;
 use std::result::Result;
 use std::{boxed, error};
-use tokio_core::reactor::Core;
+use tokio::runtime::current_thread::Runtime;
 
 fn main() {
     let registry = match std::env::args().nth(1) {
@@ -37,7 +37,7 @@ fn run(
     user: Option<String>,
     passwd: Option<String>,
 ) -> Result<(), boxed::Box<error::Error>> {
-    let mut tcore = Core::new()?;
+    let mut runtime = Runtime::new()?;
 
     let mut client = dkregistry::v2::Client::configure()
         .registry(host)
@@ -51,7 +51,7 @@ fn run(
     let futures = common::authenticate_client(&mut client, &login_scope)
         .and_then(|dclient| dclient.is_v2_supported());
 
-    match tcore.run(futures) {
+    match runtime.block_on(futures) {
         Ok(login_successful) if login_successful => Ok(()),
         Err(e) => Err(Box::new(e)),
         _ => Err("Login unsucessful".into()),

--- a/examples/login.rs
+++ b/examples/login.rs
@@ -39,7 +39,7 @@ fn run(
 ) -> Result<(), boxed::Box<error::Error>> {
     let mut tcore = Core::new()?;
 
-    let mut client = dkregistry::v2::Client::configure(&tcore.handle())
+    let mut client = dkregistry::v2::Client::configure()
         .registry(host)
         .insecure_registry(false)
         .username(user)

--- a/examples/tags.rs
+++ b/examples/tags.rs
@@ -1,13 +1,13 @@
 extern crate dkregistry;
 extern crate futures;
-extern crate tokio_core;
+extern crate tokio;
 
 mod common;
 
 use futures::prelude::*;
 use std::result::Result;
 use std::{boxed, error};
-use tokio_core::reactor::Core;
+use tokio::runtime::current_thread::Runtime;
 
 fn main() {
     let registry = match std::env::args().nth(1) {
@@ -44,7 +44,7 @@ fn run(
     passwd: Option<String>,
     image: &str,
 ) -> Result<(), boxed::Box<error::Error>> {
-    let mut tcore = Core::new()?;
+    let mut runtime = Runtime::new()?;
     let mut client = dkregistry::v2::Client::configure()
         .registry(host)
         .insecure_registry(false)
@@ -63,7 +63,7 @@ fn run(
             Ok(())
         });
 
-    match tcore.run(futures) {
+    match runtime.block_on(futures) {
         Ok(_) => Ok(()),
         Err(e) => Err(Box::new(e)),
     }

--- a/examples/tags.rs
+++ b/examples/tags.rs
@@ -45,7 +45,7 @@ fn run(
     image: &str,
 ) -> Result<(), boxed::Box<error::Error>> {
     let mut tcore = Core::new()?;
-    let mut client = dkregistry::v2::Client::configure(&tcore.handle())
+    let mut client = dkregistry::v2::Client::configure()
         .registry(host)
         .insecure_registry(false)
         .username(user)

--- a/examples/trace.rs
+++ b/examples/trace.rs
@@ -69,7 +69,7 @@ fn run(
     let version = dkr_ref.version();
     let mut tcore = Core::new()?;
 
-    let mut client = dkregistry::v2::Client::configure(&tcore.handle())
+    let mut client = dkregistry::v2::Client::configure()
         .registry(&dkr_ref.registry())
         .insecure_registry(false)
         .username(user)

--- a/examples/trace.rs
+++ b/examples/trace.rs
@@ -4,7 +4,7 @@ extern crate env_logger;
 extern crate futures;
 extern crate log;
 extern crate serde_json;
-extern crate tokio_core;
+extern crate tokio;
 
 mod common;
 
@@ -12,7 +12,7 @@ use dkregistry::reference;
 use futures::prelude::*;
 use std::str::FromStr;
 use std::{boxed, env, error, fs, io};
-use tokio_core::reactor::Core;
+use tokio::runtime::current_thread::Runtime;
 
 fn main() {
     let dkr_ref = match std::env::args().nth(1) {
@@ -67,7 +67,7 @@ fn run(
 
     let image = dkr_ref.repository();
     let version = dkr_ref.version();
-    let mut tcore = Core::new()?;
+    let mut runtime = Runtime::new()?;
 
     let mut client = dkregistry::v2::Client::configure()
         .registry(&dkr_ref.registry())
@@ -129,7 +129,7 @@ fn run(
                 .collect()
         });
 
-    let blobs = match tcore.run(futures) {
+    let blobs = match runtime.block_on(futures) {
         Ok(blobs) => blobs,
         Err(e) => return Err(Box::new(e)),
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //! // Check whether a registry supports API v2.
 //! let host = "quay.io";
 //! let mut tcore = Core::new()?;
-//! let dclient = Client::configure(&tcore.handle())
+//! let dclient = Client::configure()
 //!                      .insecure_registry(false)
 //!                      .registry(host)
 //!                      .build()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,22 +7,22 @@
 //!
 //! ```rust,no_run
 //! # extern crate dkregistry;
-//! # extern crate tokio_core;
+//! # extern crate tokio;
 //! # fn main() {
 //! # fn run() -> dkregistry::errors::Result<()> {
 //! #
-//! use tokio_core::reactor::Core;
+//! use tokio::runtime::current_thread::Runtime;
 //! use dkregistry::v2::Client;
 //!
 //! // Check whether a registry supports API v2.
 //! let host = "quay.io";
-//! let mut tcore = Core::new()?;
+//! let mut runtime = Runtime::new()?;
 //! let dclient = Client::configure()
 //!                      .insecure_registry(false)
 //!                      .registry(host)
 //!                      .build()?;
 //! let check = dclient.is_v2_supported();
-//! match tcore.run(check)? {
+//! match runtime.block_on(check)? {
 //!     false => println!("{} does NOT support v2", host),
 //!     true => println!("{} supports v2", host),
 //! };
@@ -43,7 +43,6 @@ extern crate hyper_rustls;
 extern crate mime;
 extern crate serde;
 extern crate serde_json;
-extern crate tokio_core;
 #[macro_use]
 extern crate error_chain;
 #[macro_use]

--- a/src/v2/config.rs
+++ b/src/v2/config.rs
@@ -5,7 +5,6 @@ use v2::*;
 #[derive(Debug)]
 pub struct Config {
     config: client::Client<hyper_rustls::HttpsConnector<client::HttpConnector>, hyper::Body>,
-    handle: reactor::Handle,
     index: String,
     insecure_registry: bool,
     user_agent: Option<String>,
@@ -15,12 +14,11 @@ pub struct Config {
 
 impl Config {
     /// Initialize `Config` with default values.
-    pub fn default(handle: &reactor::Handle) -> Self {
+    pub fn default() -> Self {
         let dns_threads = 4;
         Self {
             config: hyper::client::Client::builder()
                 .build(hyper_rustls::HttpsConnector::new(dns_threads)),
-            handle: handle.clone(),
             index: "registry-1.docker.io".into(),
             insecure_registry: false,
             user_agent: Some(::USER_AGENT.to_owned()),

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -8,20 +8,20 @@
 //!
 //! ```rust,no_run
 //! # extern crate dkregistry;
-//! # extern crate tokio_core;
+//! # extern crate tokio;
 //! # fn main() {
 //! # fn run() -> dkregistry::errors::Result<()> {
 //! #
-//! use tokio_core::reactor::Core;
+//! use tokio::runtime::current_thread::Runtime;
 //! use dkregistry::v2::Client;
 //!
 //! // Retrieve an image manifest.
-//! let mut tcore = Core::new()?;
+//! let mut runtime = Runtime::new()?;
 //! let dclient = Client::configure()
 //!                      .registry("quay.io")
 //!                      .build()?;
 //! let fetch = dclient.get_manifest("coreos/etcd", "v3.1.0");
-//! let manifest = tcore.run(fetch)?;
+//! let manifest = runtime.block_on(fetch)?;
 //! #
 //! # Ok(())
 //! # };

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -17,7 +17,7 @@
 //!
 //! // Retrieve an image manifest.
 //! let mut tcore = Core::new()?;
-//! let dclient = Client::configure(&tcore.handle())
+//! let dclient = Client::configure()
 //!                      .registry("quay.io")
 //!                      .build()?;
 //! let fetch = dclient.get_manifest("coreos/etcd", "v3.1.0");
@@ -34,7 +34,6 @@ use futures;
 use hyper::{self, client, header};
 use hyper_rustls;
 use serde_json;
-use tokio_core::reactor;
 
 use futures::Future;
 use std::str::FromStr;
@@ -74,8 +73,8 @@ pub type FutureBool = Box<futures::Future<Item = bool, Error = Error>>;
 pub type FutureManifest = Box<futures::Future<Item = Vec<u8>, Error = Error>>;
 
 impl Client {
-    pub fn configure(handle: &reactor::Handle) -> Config {
-        Config::default(handle)
+    pub fn configure() -> Config {
+        Config::default()
     }
 
     fn new_request(

--- a/tests/mock/api_version.rs
+++ b/tests/mock/api_version.rs
@@ -17,7 +17,7 @@ fn test_version_check_status_ok() {
         .create();
 
     let mut tcore = Core::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
         .username(None)
@@ -44,7 +44,7 @@ fn test_version_check_status_unauth() {
         .create();
 
     let mut tcore = Core::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
         .username(None)
@@ -69,7 +69,7 @@ fn test_version_check_status_notfound() {
         .create();
 
     let mut tcore = Core::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
         .username(None)
@@ -94,7 +94,7 @@ fn test_version_check_status_forbidden() {
         .create();
 
     let mut tcore = Core::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
         .username(None)
@@ -116,7 +116,7 @@ fn test_version_check_noheader() {
     let _m = mock("GET", "/v2/").with_status(403).create();
 
     let mut tcore = Core::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
         .username(None)
@@ -141,7 +141,7 @@ fn test_version_check_trailing_slash() {
         .create();
 
     let mut tcore = Core::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
         .username(None)

--- a/tests/mock/api_version.rs
+++ b/tests/mock/api_version.rs
@@ -1,9 +1,9 @@
 extern crate dkregistry;
 extern crate mockito;
-extern crate tokio_core;
+extern crate tokio;
 
 use self::mockito::mock;
-use self::tokio_core::reactor::Core;
+use self::tokio::runtime::current_thread::Runtime;
 
 static API_VERSION_K: &'static str = "Docker-Distribution-API-Version";
 static API_VERSION_V: &'static str = "registry/2.0";
@@ -16,7 +16,7 @@ fn test_version_check_status_ok() {
         .with_header(API_VERSION_K, API_VERSION_V)
         .create();
 
-    let mut tcore = Core::new().unwrap();
+    let mut runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
@@ -26,11 +26,11 @@ fn test_version_check_status_ok() {
         .unwrap();
 
     let is_v2 = dclient.is_v2_supported();
-    let ok = tcore.run(is_v2).unwrap();
+    let ok = runtime.block_on(is_v2).unwrap();
     assert_eq!(ok, true);
 
     let ensure_v2 = dclient.ensure_v2_registry();
-    let dclient = tcore.run(ensure_v2).unwrap();
+    let _dclient = runtime.block_on(ensure_v2).unwrap();
 
     mockito::reset();
 }
@@ -43,7 +43,7 @@ fn test_version_check_status_unauth() {
         .with_header(API_VERSION_K, API_VERSION_V)
         .create();
 
-    let mut tcore = Core::new().unwrap();
+    let mut runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
@@ -54,7 +54,7 @@ fn test_version_check_status_unauth() {
 
     let futcheck = dclient.is_v2_supported();
 
-    let res = tcore.run(futcheck).unwrap();
+    let res = runtime.block_on(futcheck).unwrap();
     assert_eq!(res, true);
 
     mockito::reset();
@@ -68,7 +68,7 @@ fn test_version_check_status_notfound() {
         .with_header(API_VERSION_K, API_VERSION_V)
         .create();
 
-    let mut tcore = Core::new().unwrap();
+    let mut runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
@@ -79,7 +79,7 @@ fn test_version_check_status_notfound() {
 
     let futcheck = dclient.is_v2_supported();
 
-    let res = tcore.run(futcheck).unwrap();
+    let res = runtime.block_on(futcheck).unwrap();
     assert_eq!(res, false);
 
     mockito::reset();
@@ -93,7 +93,7 @@ fn test_version_check_status_forbidden() {
         .with_header(API_VERSION_K, API_VERSION_V)
         .create();
 
-    let mut tcore = Core::new().unwrap();
+    let mut runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
@@ -104,7 +104,7 @@ fn test_version_check_status_forbidden() {
 
     let futcheck = dclient.is_v2_supported();
 
-    let res = tcore.run(futcheck).unwrap();
+    let res = runtime.block_on(futcheck).unwrap();
     assert_eq!(res, false);
 
     mockito::reset();
@@ -115,7 +115,7 @@ fn test_version_check_noheader() {
     let addr = mockito::server_address().to_string();
     let _m = mock("GET", "/v2/").with_status(403).create();
 
-    let mut tcore = Core::new().unwrap();
+    let mut runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
@@ -126,7 +126,7 @@ fn test_version_check_noheader() {
 
     let futcheck = dclient.is_v2_supported();
 
-    let res = tcore.run(futcheck).unwrap();
+    let res = runtime.block_on(futcheck).unwrap();
     assert_eq!(res, false);
 
     mockito::reset();
@@ -140,7 +140,7 @@ fn test_version_check_trailing_slash() {
         .with_header(API_VERSION_K, API_VERSION_V)
         .create();
 
-    let mut tcore = Core::new().unwrap();
+    let mut runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
@@ -151,7 +151,7 @@ fn test_version_check_trailing_slash() {
 
     let futcheck = dclient.is_v2_supported();
 
-    let res = tcore.run(futcheck).unwrap();
+    let res = runtime.block_on(futcheck).unwrap();
     assert_eq!(res, false);
 
     mockito::reset();

--- a/tests/mock/base_client.rs
+++ b/tests/mock/base_client.rs
@@ -17,7 +17,7 @@ fn test_base_no_insecure() {
         .create();
 
     let mut tcore = Core::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(false)
         .username(None)
@@ -44,7 +44,7 @@ fn test_base_useragent() {
         .create();
 
     let mut tcore = Core::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
         .username(None)
@@ -72,7 +72,7 @@ fn test_base_custom_useragent() {
         .create();
 
     let mut tcore = Core::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
         .user_agent(Some(ua.to_string()))
@@ -99,7 +99,7 @@ fn test_base_no_useragent() {
         .create();
 
     let mut tcore = Core::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
         .user_agent(None)

--- a/tests/mock/base_client.rs
+++ b/tests/mock/base_client.rs
@@ -1,9 +1,9 @@
 extern crate dkregistry;
 extern crate mockito;
-extern crate tokio_core;
+extern crate tokio;
 
 use self::mockito::mock;
-use self::tokio_core::reactor::Core;
+use self::tokio::runtime::current_thread::Runtime;
 
 static API_VERSION_K: &'static str = "Docker-Distribution-API-Version";
 static API_VERSION_V: &'static str = "registry/2.0";
@@ -16,7 +16,7 @@ fn test_base_no_insecure() {
         .with_header(API_VERSION_K, API_VERSION_V)
         .create();
 
-    let mut tcore = Core::new().unwrap();
+    let mut runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(false)
@@ -29,7 +29,7 @@ fn test_base_no_insecure() {
 
     // This relies on the fact that mockito is HTTP-only and
     // trying to speak TLS to it results in garbage/errors.
-    tcore.run(futcheck).is_err();
+    runtime.block_on(futcheck).is_err();
 
     mockito::reset();
 }
@@ -43,7 +43,7 @@ fn test_base_useragent() {
         .with_header(API_VERSION_K, API_VERSION_V)
         .create();
 
-    let mut tcore = Core::new().unwrap();
+    let mut runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
@@ -54,7 +54,7 @@ fn test_base_useragent() {
 
     let futcheck = dclient.is_v2_supported();
 
-    let res = tcore.run(futcheck).unwrap();
+    let res = runtime.block_on(futcheck).unwrap();
     assert_eq!(res, true);
 
     mockito::reset();
@@ -71,7 +71,7 @@ fn test_base_custom_useragent() {
         .with_header(API_VERSION_K, API_VERSION_V)
         .create();
 
-    let mut tcore = Core::new().unwrap();
+    let mut runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
@@ -83,7 +83,7 @@ fn test_base_custom_useragent() {
 
     let futcheck = dclient.is_v2_supported();
 
-    let res = tcore.run(futcheck).unwrap();
+    let res = runtime.block_on(futcheck).unwrap();
     assert_eq!(res, true);
 
     mockito::reset();
@@ -98,7 +98,7 @@ fn test_base_no_useragent() {
         .with_header(API_VERSION_K, API_VERSION_V)
         .create();
 
-    let mut tcore = Core::new().unwrap();
+    let mut runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
@@ -110,7 +110,7 @@ fn test_base_no_useragent() {
 
     let futcheck = dclient.is_v2_supported();
 
-    let res = tcore.run(futcheck).unwrap();
+    let res = runtime.block_on(futcheck).unwrap();
     assert_eq!(res, true);
 
     mockito::reset();

--- a/tests/mock/blobs_download.rs
+++ b/tests/mock/blobs_download.rs
@@ -1,9 +1,9 @@
 extern crate dkregistry;
 extern crate mockito;
-extern crate tokio_core;
+extern crate tokio;
 
 use self::mockito::mock;
-use self::tokio_core::reactor::Core;
+use self::tokio::runtime::current_thread::Runtime;
 
 #[test]
 fn test_blobs_has_layer() {
@@ -19,7 +19,7 @@ fn test_blobs_has_layer() {
         .with_header("Docker-Content-Digest", binary_digest)
         .create();
 
-    let mut tcore = Core::new().unwrap();
+    let mut runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
@@ -30,7 +30,7 @@ fn test_blobs_has_layer() {
 
     let futcheck = dclient.has_blob(name, digest);
 
-    let res = tcore.run(futcheck).unwrap();
+    let res = runtime.block_on(futcheck).unwrap();
     assert_eq!(res, true);
 
     mockito::reset();
@@ -45,7 +45,7 @@ fn test_blobs_hasnot_layer() {
     let addr = mockito::server_address().to_string();
     let _m = mock("HEAD", ep.as_str()).with_status(404).create();
 
-    let mut tcore = Core::new().unwrap();
+    let mut runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
@@ -56,7 +56,7 @@ fn test_blobs_hasnot_layer() {
 
     let futcheck = dclient.has_blob(name, digest);
 
-    let res = tcore.run(futcheck).unwrap();
+    let res = runtime.block_on(futcheck).unwrap();
     assert_eq!(res, false);
 
     mockito::reset();

--- a/tests/mock/blobs_download.rs
+++ b/tests/mock/blobs_download.rs
@@ -20,7 +20,7 @@ fn test_blobs_has_layer() {
         .create();
 
     let mut tcore = Core::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
         .username(None)
@@ -46,7 +46,7 @@ fn test_blobs_hasnot_layer() {
     let _m = mock("HEAD", ep.as_str()).with_status(404).create();
 
     let mut tcore = Core::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
         .username(None)

--- a/tests/mock/catalog.rs
+++ b/tests/mock/catalog.rs
@@ -19,7 +19,7 @@ fn test_catalog_simple() {
         .create();
 
     let mut tcore = Core::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
         .username(None)
@@ -60,7 +60,7 @@ fn test_catalog_paginate() {
         .create();
 
     let mut tcore = Core::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
         .username(None)

--- a/tests/mock/tags.rs
+++ b/tests/mock/tags.rs
@@ -21,7 +21,7 @@ fn test_tags_simple() {
         .create();
 
     let mut tcore = Core::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
         .username(None)
@@ -65,7 +65,7 @@ fn test_tags_paginate() {
         .create();
 
     let mut tcore = Core::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
         .username(None)
@@ -98,7 +98,7 @@ fn test_tags_404() {
         .create();
 
     let mut tcore = Core::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
         .username(None)
@@ -127,7 +127,7 @@ fn test_tags_missing_header() {
         .create();
 
     let mut tcore = Core::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
         .username(None)

--- a/tests/net/docker_io/mod.rs
+++ b/tests/net/docker_io/mod.rs
@@ -32,7 +32,7 @@ fn test_dockerio_base() {
     };
 
     let mut tcore = Core::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = dkregistry::v2::Client::configure()
         .registry(REGISTRY)
         .insecure_registry(false)
         .username(Some(user))
@@ -49,7 +49,7 @@ fn test_dockerio_base() {
 #[test]
 fn test_dockerio_insecure() {
     let mut tcore = Core::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = dkregistry::v2::Client::configure()
         .registry(REGISTRY)
         .insecure_registry(true)
         .username(None)

--- a/tests/net/docker_io/mod.rs
+++ b/tests/net/docker_io/mod.rs
@@ -1,7 +1,7 @@
 extern crate dkregistry;
-extern crate tokio_core;
+extern crate tokio;
 
-use self::tokio_core::reactor::Core;
+use self::tokio::runtime::current_thread::Runtime;
 
 static REGISTRY: &'static str = "registry-1.docker.io";
 
@@ -31,7 +31,7 @@ fn test_dockerio_base() {
         None => return,
     };
 
-    let mut tcore = Core::new().unwrap();
+    let mut runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(REGISTRY)
         .insecure_registry(false)
@@ -42,13 +42,13 @@ fn test_dockerio_base() {
 
     let futcheck = dclient.is_v2_supported();
 
-    let res = tcore.run(futcheck).unwrap();
+    let res = runtime.block_on(futcheck).unwrap();
     assert_eq!(res, true);
 }
 
 #[test]
 fn test_dockerio_insecure() {
-    let mut tcore = Core::new().unwrap();
+    let mut runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(REGISTRY)
         .insecure_registry(true)
@@ -59,6 +59,6 @@ fn test_dockerio_insecure() {
 
     let futcheck = dclient.is_v2_supported();
 
-    let res = tcore.run(futcheck).unwrap();
+    let res = runtime.block_on(futcheck).unwrap();
     assert_eq!(res, false);
 }

--- a/tests/net/gcr_io/mod.rs
+++ b/tests/net/gcr_io/mod.rs
@@ -34,7 +34,7 @@ fn test_gcrio_base() {
     };
 
     let mut tcore = Core::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = dkregistry::v2::Client::configure()
         .registry(REGISTRY)
         .insecure_registry(false)
         .username(Some(user))
@@ -51,7 +51,7 @@ fn test_gcrio_base() {
 #[test]
 fn test_gcrio_insecure() {
     let mut tcore = Core::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = dkregistry::v2::Client::configure()
         .registry(REGISTRY)
         .insecure_registry(true)
         .username(None)
@@ -68,7 +68,7 @@ fn test_gcrio_insecure() {
 #[test]
 fn test_gcrio_get_tags() {
     let mut tcore = Core::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = dkregistry::v2::Client::configure()
         .registry(REGISTRY)
         .insecure_registry(false)
         .username(None)
@@ -87,7 +87,7 @@ fn test_gcrio_get_tags() {
 #[test]
 fn test_gcrio_has_manifest() {
     let mut tcore = Core::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = dkregistry::v2::Client::configure()
         .registry(REGISTRY)
         .insecure_registry(false)
         .username(None)

--- a/tests/net/quay_io/mod.rs
+++ b/tests/net/quay_io/mod.rs
@@ -38,7 +38,7 @@ fn test_quayio_base() {
     };
 
     let mut tcore = Core::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = dkregistry::v2::Client::configure()
         .registry(REGISTRY)
         .insecure_registry(false)
         .username(Some(user))
@@ -55,7 +55,7 @@ fn test_quayio_base() {
 #[test]
 fn test_quayio_insecure() {
     let mut tcore = Core::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = dkregistry::v2::Client::configure()
         .registry(REGISTRY)
         .insecure_registry(true)
         .username(None)
@@ -78,7 +78,7 @@ fn test_quayio_auth_login() {
     };
 
     let mut tcore = Core::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = dkregistry::v2::Client::configure()
         .registry(REGISTRY)
         .insecure_registry(false)
         .username(Some(user))
@@ -99,7 +99,7 @@ fn test_quayio_auth_login() {
 #[test]
 fn test_quayio_get_tags_simple() {
     let mut tcore = Core::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = dkregistry::v2::Client::configure()
         .registry(REGISTRY)
         .insecure_registry(false)
         .username(None)
@@ -118,7 +118,7 @@ fn test_quayio_get_tags_simple() {
 #[test]
 fn test_quayio_get_tags_limit() {
     let mut tcore = Core::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = dkregistry::v2::Client::configure()
         .registry(REGISTRY)
         .insecure_registry(false)
         .username(None)
@@ -137,7 +137,7 @@ fn test_quayio_get_tags_limit() {
 #[test]
 fn test_quayio_get_tags_pagination() {
     let mut tcore = Core::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = dkregistry::v2::Client::configure()
         .registry(REGISTRY)
         .insecure_registry(false)
         .username(None)
@@ -163,7 +163,7 @@ fn test_quayio_auth_tags() {
     };
 
     let mut tcore = Core::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = dkregistry::v2::Client::configure()
         .registry(REGISTRY)
         .insecure_registry(false)
         .username(Some(user))
@@ -196,7 +196,7 @@ fn test_quayio_auth_tags() {
 #[test]
 fn test_quayio_has_manifest() {
     let mut tcore = Core::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = dkregistry::v2::Client::configure()
         .registry(REGISTRY)
         .insecure_registry(false)
         .username(None)
@@ -223,7 +223,7 @@ fn test_quayio_auth_manifest() {
     };
 
     let mut tcore = Core::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = dkregistry::v2::Client::configure()
         .registry(REGISTRY)
         .insecure_registry(false)
         .username(Some(user))
@@ -255,7 +255,7 @@ fn test_quayio_auth_manifest() {
 #[test]
 fn test_quayio_has_no_manifest() {
     let mut tcore = Core::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = dkregistry::v2::Client::configure()
         .registry(REGISTRY)
         .insecure_registry(false)
         .username(None)
@@ -285,7 +285,7 @@ fn test_quayio_auth_layer_blob() {
     };
 
     let mut tcore = Core::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure(&tcore.handle())
+    let dclient = dkregistry::v2::Client::configure()
         .registry(REGISTRY)
         .insecure_registry(false)
         .username(Some(user))


### PR DESCRIPTION
@lucab PTAL and let me know if I'm missing something or if the handle is indeed unused