### PR TITLE
Release 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dkregistry"
-version = "0.3.0-alpha.0"
+version = "0.3.0"
 authors = ["Luca Bruno <lucab@debian.org>", "Stefan Junker <sjunker@redhat.com>"]
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/dkregistry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dkregistry"
-version = "0.3.0"
+version = "0.3.1-alpha.0"
 authors = ["Luca Bruno <lucab@debian.org>", "Stefan Junker <sjunker@redhat.com>"]
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/dkregistry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dkregistry"
-version = "0.2.2-alpha.0"
+version = "0.3.0-alpha.0"
 authors = ["Luca Bruno <lucab@debian.org>", "Stefan Junker <sjunker@redhat.com>"]
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/dkregistry"


### PR DESCRIPTION
Relevant changes:
 * dkregistry: remove tokio-core, use tokio instead
 * client: add an ensure_v2 helper
 * blobs: switch from hyper to reqwest
 * lib/get_credentials: include unfound index in error message
 * manifest/v2s1: add `get_labels()` method, test and example
 * dkregistry: format with 1.31.0 toolchain
 * cargo/maintainers: add Stefan Junker