### PR TITLE
 v2/manifest: add get_manifest_and_ref method

### DIFF
--- a/src/v2/auth.rs
+++ b/src/v2/auth.rs
@@ -32,7 +32,7 @@ impl Client {
                     return Box::new(futures::future::err::<_, _>(Error::from(format!(
                         "failed to parse url from string: {}",
                         e
-                    ))))
+                    ))));
                 }
             }
         };

--- a/src/v2/manifest/mod.rs
+++ b/src/v2/manifest/mod.rs
@@ -2,7 +2,7 @@
 use mediatypes;
 use v2::*;
 
-use futures::Stream;
+use futures::{future, Stream};
 use hyper::header;
 use hyper::StatusCode;
 use mime;
@@ -100,7 +100,7 @@ impl Client {
                 Err(e) => {
                     let msg = format!("failed to parse Uri from str: {}", e);
                     error!("{}", msg);
-                    return Box::new(futures::future::err::<_, _>(Error::from(msg)));
+                    return Box::new(future::err::<_, _>(Error::from(msg)));
                 }
             }
         };
@@ -118,7 +118,7 @@ impl Client {
         } {
             Ok(x) => x,
             Err(e) => {
-                return Box::new(futures::future::err::<_, _>(Error::from(format!(
+                return Box::new(future::err::<_, _>(Error::from(format!(
                     "failed to match mediatypes: {}",
                     e
                 ))));
@@ -131,7 +131,7 @@ impl Client {
                 Err(e) => {
                     let msg = format!("new_request failed: {}", e);
                     error!("{}", msg);
-                    return Box::new(futures::future::err(Error::from(msg)));
+                    return Box::new(future::err(Error::from(msg)));
                 }
             };
             for v in accept_types {

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -72,6 +72,9 @@ pub type FutureBool = Box<futures::Future<Item = bool, Error = Error>>;
 /// Convenience alias for a future manifest blob.
 pub type FutureManifest = Box<futures::Future<Item = Vec<u8>, Error = Error>>;
 
+/// Convenience alias for a future manifest blob and ref.
+pub type FutureManifestAndRef = Box<futures::Future<Item = (Vec<u8>, String), Error = Error>>;
+
 impl Client {
     pub fn configure() -> Config {
         Config::default()

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -125,7 +125,7 @@ impl Client {
                 return Box::new(futures::future::err::<_, _>(Error::from(format!(
                     "failed to parse url from string: {}",
                     e
-                ))))
+                ))));
             }
         };
         let req = match self.new_request(hyper::Method::GET, url.clone()) {


### PR DESCRIPTION
This method returns the manifestref in addition to the manifest.  As
part of the migration to reqwest the method is a rewrite of
`get_manifest(..)`, which now wraps the new one and omits the
manifestref from the result.