### PR TITLE
Revert "Update hyper-rustls requirement from 0.15 to 0.16"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ base64 = "0.10"
 error-chain = { version = "0.12", default-features = false }
 futures = "0.1"
 hyper = "0.12"
-hyper-rustls = "0.16"
+hyper-rustls = "0.15"
 http = "0.1"
 libflate = "0.1"
 log = "0.4"


### PR DESCRIPTION
Reverts camallo/dkregistry-rs#84.

Fixes #87.