### PR TITLE
v2: switch version probing to reqwest

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,6 +3,7 @@
 use base64;
 use http;
 use hyper;
+use reqwest;
 use serde_json;
 use std::{io, string};
 
@@ -14,6 +15,7 @@ error_chain! {
         Hyper(hyper::Error);
         Io(io::Error);
         Json(serde_json::Error);
+        Reqwest(reqwest::Error);
         UriParse(http::uri::InvalidUri);
         Utf8Parse(string::FromUtf8Error);
     }

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -30,12 +30,11 @@
 //! ```
 
 use super::errors::*;
-use futures;
+use futures::prelude::*;
 use hyper::{self, client, header};
 use hyper_rustls;
 use serde_json;
 
-use futures::Future;
 use std::str::FromStr;
 
 mod config;
@@ -67,13 +66,13 @@ pub struct Client {
 }
 
 /// Convenience alias for a future boolean result.
-pub type FutureBool = Box<futures::Future<Item = bool, Error = Error>>;
+pub type FutureBool = Box<Future<Item = bool, Error = Error>>;
 
 /// Convenience alias for a future manifest blob.
-pub type FutureManifest = Box<futures::Future<Item = Vec<u8>, Error = Error>>;
+pub type FutureManifest = Box<Future<Item = Vec<u8>, Error = Error>>;
 
 /// Convenience alias for a future manifest blob and ref.
-pub type FutureManifestAndRef = Box<futures::Future<Item = (Vec<u8>, String), Error = Error>>;
+pub type FutureManifestAndRef = Box<Future<Item = (Vec<u8>, String), Error = Error>>;
 
 impl Client {
     pub fn configure() -> Config {

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -161,13 +161,18 @@ impl Client {
     /// Takes reqwest's async RequestBuilder and injects an authentication header if a token is present
     fn build_reqwest(
         &self,
-        client: reqwest::async::RequestBuilder,
+        req_builder: reqwest::async::RequestBuilder,
     ) -> reqwest::async::RequestBuilder {
+        let mut builder = req_builder;
+
         if let Some(token) = &self.token {
-            client.header(reqwest::header::AUTHORIZATION, format!("Bearer {}", token))
-        } else {
-            client
+            builder = builder.header(reqwest::header::AUTHORIZATION, format!("Bearer {}", token))
         }
+        if let Some(ua) = &self.user_agent {
+            builder = builder.header(reqwest::header::USER_AGENT, ua.as_str());
+        };
+
+        builder
     }
 }
 

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -117,45 +117,35 @@ impl Client {
     }
 
     /// Check whether remote registry supports v2 API.
-    pub fn is_v2_supported(&self) -> FutureBool {
+    pub fn is_v2_supported(&self) -> impl Future<Item = bool, Error = Error> {
         let api_header = "Docker-Distribution-API-Version";
         let api_version = "registry/2.0";
 
-        let url = match hyper::Uri::from_str((self.base_url.clone() + "/v2/").as_str()) {
-            Ok(url) => url,
-            Err(e) => {
-                return Box::new(futures::future::err::<_, _>(Error::from(format!(
-                    "failed to parse url from string: {}",
-                    e
-                ))));
-            }
-        };
-        let req = match self.new_request(hyper::Method::GET, url.clone()) {
-            Ok(r) => r,
-            Err(e) => {
-                let msg = format!("new_request failed: {}", e);
-                error!("{}", msg);
-                return Box::new(futures::future::err::<_, _>(Error::from(msg)));
-            }
-        };
-        let freq = self.hclient.request(req);
-        let fres = freq
-            .from_err()
-            .inspect(move |_| {
+        // GET request to bare v2 endpoint.
+        let v2_endpoint = format!("{}/v2/", self.base_url);
+        let get_v2 = reqwest::Url::parse(&v2_endpoint)
+            .chain_err(|| format!("failed to parse url string '{}'", &v2_endpoint))
+            .map(|url| {
                 trace!("GET {:?}", url);
+                self.build_reqwest(reqwest::async::Client::new().get(url))
             })
+            .into_future()
+            .and_then(|req| req.send().from_err());
+
+        // Check status code and API headers according to spec:
+        // https://docs.docker.com/registry/spec/api/#api-version-check
+        get_v2
             .and_then(move |r| match (r.status(), r.headers().get(api_header)) {
                 (hyper::StatusCode::OK, Some(x)) => Ok(x == api_version),
                 (hyper::StatusCode::UNAUTHORIZED, Some(x)) => Ok(x == api_version),
                 (s, v) => {
-                    trace!("Got status {}, header version {:?}", s, v);
+                    trace!("Got unexpected status {}, header version {:?}", s, v);
                     Ok(false)
                 }
             })
             .inspect(|b| {
                 trace!("v2 API supported: {}", b);
-            });
-        Box::new(fres)
+            })
     }
 
     /// Takes reqwest's async RequestBuilder and injects an authentication header if a token is present

--- a/tests/mock/base_client.rs
+++ b/tests/mock/base_client.rs
@@ -88,30 +88,3 @@ fn test_base_custom_useragent() {
 
     mockito::reset();
 }
-
-#[test]
-fn test_base_no_useragent() {
-    let addr = mockito::server_address().to_string();
-    let _m = mock("GET", "/v2/")
-        .match_header("user-agent", mockito::Matcher::Missing)
-        .with_status(200)
-        .with_header(API_VERSION_K, API_VERSION_V)
-        .create();
-
-    let mut runtime = Runtime::new().unwrap();
-    let dclient = dkregistry::v2::Client::configure()
-        .registry(&addr)
-        .insecure_registry(true)
-        .user_agent(None)
-        .username(None)
-        .password(None)
-        .build()
-        .unwrap();
-
-    let futcheck = dclient.is_v2_supported();
-
-    let res = runtime.block_on(futcheck).unwrap();
-    assert_eq!(res, true);
-
-    mockito::reset();
-}

--- a/tests/net/docker_io/mod.rs
+++ b/tests/net/docker_io/mod.rs
@@ -60,5 +60,5 @@ fn test_dockerio_insecure() {
     let futcheck = dclient.is_v2_supported();
 
     let res = runtime.block_on(futcheck).unwrap();
-    assert_eq!(res, false);
+    assert_eq!(res, true);
 }

--- a/tests/net/gcr_io/mod.rs
+++ b/tests/net/gcr_io/mod.rs
@@ -62,7 +62,7 @@ fn test_gcrio_insecure() {
     let futcheck = dclient.is_v2_supported();
 
     let res = runtime.block_on(futcheck).unwrap();
-    assert_eq!(res, false);
+    assert_eq!(res, true);
 }
 
 #[test]

--- a/tests/net/quay_io/mod.rs
+++ b/tests/net/quay_io/mod.rs
@@ -66,7 +66,7 @@ fn test_quayio_insecure() {
     let futcheck = dclient.is_v2_supported();
 
     let res = runtime.block_on(futcheck).unwrap();
-    assert_eq!(res, false);
+    assert_eq!(res, true);
 }
 
 #[test]


### PR DESCRIPTION
This changes the v2 probing logic to use the reqwest client, in order
to better support redirection.

Closes: https://github.com/camallo/dkregistry-rs/issues/89