### PR TITLE
examples: improve authentication and argument handling

### DIFF
--- a/examples/image-labels.rs
+++ b/examples/image-labels.rs
@@ -61,7 +61,7 @@ fn run(
 ) -> Result<(), dkregistry::errors::Error> {
     let mut runtime = Runtime::new()?;
 
-    let mut client = dkregistry::v2::Client::configure()
+    let client = dkregistry::v2::Client::configure()
         .registry(&dkr_ref.registry())
         .insecure_registry(false)
         .username(user)
@@ -72,7 +72,7 @@ fn run(
     let login_scope = format!("repository:{}:pull", image);
     let version = dkr_ref.version();
 
-    let futures = common::authenticate_client(&mut client, &login_scope)
+    let futures = common::authenticate_client(client, login_scope)
         .and_then(|dclient| {
             dclient
                 .has_manifest(&image, &version, None)

--- a/examples/login.rs
+++ b/examples/login.rs
@@ -37,9 +37,14 @@ fn run(
     user: Option<String>,
     passwd: Option<String>,
 ) -> Result<(), boxed::Box<error::Error>> {
+    env_logger::Builder::new()
+        .filter(Some("dkregistry"), log::LevelFilter::Trace)
+        .filter(Some("trace"), log::LevelFilter::Trace)
+        .try_init()?;
+
     let mut runtime = Runtime::new()?;
 
-    let mut client = dkregistry::v2::Client::configure()
+    let client = dkregistry::v2::Client::configure()
         .registry(host)
         .insecure_registry(false)
         .username(user)
@@ -48,7 +53,7 @@ fn run(
 
     let login_scope = "";
 
-    let futures = common::authenticate_client(&mut client, &login_scope)
+    let futures = common::authenticate_client(client, login_scope.to_string())
         .and_then(|dclient| dclient.is_v2_supported());
 
     match runtime.block_on(futures) {

--- a/examples/tags.rs
+++ b/examples/tags.rs
@@ -44,8 +44,13 @@ fn run(
     passwd: Option<String>,
     image: &str,
 ) -> Result<(), boxed::Box<error::Error>> {
+    env_logger::Builder::new()
+        .filter(Some("dkregistry"), log::LevelFilter::Trace)
+        .filter(Some("trace"), log::LevelFilter::Trace)
+        .try_init()?;
+
     let mut runtime = Runtime::new()?;
-    let mut client = dkregistry::v2::Client::configure()
+    let client = dkregistry::v2::Client::configure()
         .registry(host)
         .insecure_registry(false)
         .username(user)
@@ -54,7 +59,7 @@ fn run(
 
     let login_scope = format!("repository:{}:pull", image);
 
-    let futures = common::authenticate_client(&mut client, &login_scope)
+    let futures = common::authenticate_client(client, login_scope)
         .and_then(|dclient| dclient.get_tags(&image, Some(7)).collect())
         .and_then(|tags| {
             for tag in tags {

--- a/examples/trace.rs
+++ b/examples/trace.rs
@@ -1,8 +1,6 @@
 extern crate dirs;
 extern crate dkregistry;
-extern crate env_logger;
 extern crate futures;
-extern crate log;
 extern crate serde_json;
 extern crate tokio;
 
@@ -69,7 +67,7 @@ fn run(
     let version = dkr_ref.version();
     let mut runtime = Runtime::new()?;
 
-    let mut client = dkregistry::v2::Client::configure()
+    let client = dkregistry::v2::Client::configure()
         .registry(&dkr_ref.registry())
         .insecure_registry(false)
         .username(user)
@@ -78,7 +76,7 @@ fn run(
 
     let login_scope = "";
 
-    let futures = common::authenticate_client(&mut client, &login_scope)
+    let futures = common::authenticate_client(client, login_scope.to_string())
         .and_then(|dclient| {
             dclient
                     .has_manifest(&image, &version, None)


### PR DESCRIPTION
* Only login when actually necessary, as not all registries seem to support authentication in the way we do it here.
* Improve the argument handling for some examples