### PR TITLE
reference: rework custom hostname handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ libflate = "0.1"
 log = "0.4"
 mime = "0.3"
 mockito = { version = "0.15", optional = true }
+regex = "^1.1.0"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,6 +3,7 @@
 use base64;
 use http;
 use hyper;
+use regex;
 use reqwest;
 use serde_json;
 use std::{io, string};
@@ -15,6 +16,7 @@ error_chain! {
         Hyper(hyper::Error);
         Io(io::Error);
         Json(serde_json::Error);
+        Regex(regex::Error);
         Reqwest(reqwest::Error);
         UriParse(http::uri::InvalidUri);
         Utf8Parse(string::FromUtf8Error);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ extern crate serde_derive;
 #[macro_use]
 extern crate log;
 extern crate libflate;
+extern crate regex;
 extern crate strum;
 extern crate tar;
 #[macro_use]

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -32,6 +32,10 @@
 use std::str::FromStr;
 use std::{fmt, str};
 
+static DEFAULT_REGISTRY: &str = "registry-1.docker.io";
+static DEFAULT_TAG: &str = "latest";
+static DEFAULT_SCHEME: &str = "docker";
+
 /// Image version, either a tag or a digest.
 #[derive(Clone)]
 pub enum Version {
@@ -96,8 +100,8 @@ pub struct Reference {
 
 impl Reference {
     pub fn new(registry: Option<String>, repository: String, version: Option<Version>) -> Self {
-        let reg = registry.unwrap_or_else(|| "registry-1.docker.io".to_string());
-        let ver = version.unwrap_or_else(|| Version::Tag("latest".to_string()));
+        let reg = registry.unwrap_or_else(|| DEFAULT_REGISTRY.to_string());
+        let ver = version.unwrap_or_else(|| Version::Tag(DEFAULT_TAG.to_string()));
         Self {
             has_schema: false,
             raw_input: "".into(),
@@ -126,8 +130,8 @@ impl Reference {
     //TODO(lucab): move this to a real URL type
     pub fn to_url(&self) -> String {
         format!(
-            "docker://{}/{}{:?}",
-            self.registry, self.repository, self.version
+            "{}://{}/{}{:?}",
+            DEFAULT_SCHEME, self.registry, self.repository, self.version
         )
     }
 }
@@ -162,7 +166,8 @@ fn parse_url(s: &str) -> Result<Reference, ::errors::Error> {
     if rest.is_empty() {
         bail!("name too short");
     }
-    let mut reg = "registry-1.docker.io";
+
+    let mut reg = DEFAULT_REGISTRY;
     let split: Vec<&str> = rest.rsplitn(3, '/').collect();
     let repository = match split.len() {
         1 => "library/".to_string() + rest,

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -29,6 +29,9 @@
 // The `docker://` schema is not officially documented, but has a reference implementation:
 // https://github.com/docker/distribution/blob/v2.6.1/reference/reference.go
 
+use errors::Error;
+use regex;
+use std::collections::VecDeque;
 use std::str::FromStr;
 use std::{fmt, str};
 
@@ -149,41 +152,65 @@ impl str::FromStr for Reference {
     }
 }
 
-fn parse_url(s: &str) -> Result<Reference, ::errors::Error> {
-    // TODO(lucab): move to nom
-    let mut rest = s;
+fn parse_url(input: &str) -> Result<Reference, Error> {
+    // TODO(lucab): investigate using a grammar-based parser.
+    let mut rest = input;
+
+    // Detect and remove schema.
     let has_schema = rest.starts_with("docker://");
     if has_schema {
-        rest = s.trim_left_matches("docker://");
+        rest = input.trim_left_matches("docker://");
     };
-    let (rest, version) = match (rest.rfind('@'), rest.rfind(':')) {
-        (Some(i), _) | (None, Some(i)) => {
-            let s = rest.split_at(i);
-            (s.0, Version::from_str(s.1)?)
-        }
-        (None, None) => (rest, Version::default()),
-    };
-    if rest.is_empty() {
-        bail!("name too short");
-    }
 
-    let mut reg = DEFAULT_REGISTRY;
-    let split: Vec<&str> = rest.rsplitn(3, '/').collect();
-    let repository = match split.len() {
-        1 => "library/".to_string() + rest,
-        2 => rest.to_string(),
-        _ => {
-            reg = split[2];
-            split[1].to_string() + "/" + split[0]
+    // Split path components apart and retain non-empty ones.
+    let mut components: VecDeque<String> = rest
+        .split('/')
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+        .collect();
+
+    // Take image name and extract tag or digest-ref, if any.
+    let last = components
+        .pop_back()
+        .ok_or(Error::from("missing image name"))?;
+    let (image_name, version) = match (last.rfind('@'), last.rfind(':')) {
+        (Some(i), _) | (None, Some(i)) => {
+            let s = last.split_at(i);
+            (String::from(s.0), Version::from_str(s.1)?)
         }
+        (None, None) => (last, Version::default()),
     };
-    if repository.len() > 127 {
-        bail!("name too long");
+    ensure!(!image_name.is_empty(), "empty image name");
+
+    // Handle images in default library namespace, that is:
+    // `ubuntu` -> `library/ubuntu`
+    if components.is_empty() {
+        components.push_back("library".to_string());
     }
+    components.push_back(image_name);
+
+    // Take first component and check if it is a hostname or a path component,
+    // according to regex at https://docs.docker.com/registry/spec/api/#overview.
+    let first = components
+        .pop_front()
+        .ok_or(Error::from("missing image name"))?;
+    let path_re = regex::Regex::new("^[a-z0-9]+(?:[._-][a-z0-9]+)*$")?;
+    let registry = if path_re.is_match(&first) {
+        components.push_front(first);
+        DEFAULT_REGISTRY.to_string()
+    } else {
+        first
+    };
+
+    // Re-assemble repository name.
+    let repository = components.into_iter().collect::<Vec<_>>().join("/");
+    ensure!(!repository.is_empty(), "empty repository name");
+    ensure!(repository.len() <= 127, "repository name too long");
+
     Ok(Reference {
         has_schema,
-        raw_input: s.to_string(),
-        registry: reg.to_string(),
+        raw_input: input.to_string(),
+        registry,
         repository,
         version,
     })

--- a/tests/reference.rs
+++ b/tests/reference.rs
@@ -6,13 +6,14 @@ use spectral::prelude::*;
 use std::str::FromStr;
 
 #[test]
-fn test_reference_repo() {
+fn valid_references() {
     let tcases = vec![
         "library/busybox",
         "busybox",
         "busybox:tag",
         "busybox:5000",
         "busybox@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "registry.example.com:5000/library/busybox:5000",
     ];
 
     for t in tcases {
@@ -26,11 +27,26 @@ fn test_reference_repo() {
 }
 
 #[test]
-fn test_reference_error() {
+fn invalid_references() {
     let tcases = vec!["".into(), "L".repeat(128), ":justatag".into()];
 
     for t in tcases.iter() {
         let r = Reference::from_str(t);
         asserting(t).that(&r).is_err();
     }
+}
+
+#[test]
+fn hostname_without_namespace() {
+    let dkr_ref = Reference::from_str(
+        "sat-r220-02.lab.eng.rdu2.redhat.com:5000/default_organization-custom-ocp",
+    )
+    .unwrap();
+
+    assert_eq!(
+        dkr_ref.registry(),
+        "sat-r220-02.lab.eng.rdu2.redhat.com:5000"
+    );
+    assert_eq!(dkr_ref.repository(), "default_organization-custom-ocp");
+    assert_eq!(dkr_ref.version(), "latest");
 }


### PR DESCRIPTION
This reworks the reference parser in order to better handle references with custom hostnames.

Supersedes: https://github.com/camallo/dkregistry-rs/pull/93