### PR TITLE
cargo: expose reqwest TLS feature flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,13 +30,16 @@ strum_macros = "0.13"
 tar = "0.4"
 tokio = "0.1"
 dirs = "1.0"
-reqwest = "0.9"
+reqwest = { version = "^0.9.6", default-features = false }
 
 [dev-dependencies]
 env_logger = "0.6"
 spectral = "0.6"
 
 [features]
+default = ["reqwest-default-tls"]
+reqwest-default-tls = ["reqwest/default-tls"]
+reqwest-rustls = ["reqwest/rustls-tls"]
 test-net = []
 test-mock = ["mockito"]
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ conformant to the [Docker Registry HTTP API V2][registry-v2] specification.
 
 [registry-v2]: https://docs.docker.com/registry/spec/api/
 
+## Configurable features
+
+The following is a list of [Cargo features][cargo-features] that consumers can enable or disable:
+
+ * **reqwest-default-tls** *(enabled by default)*: provides TLS support via [system-specific library][native-tls] (OpenSSL on Linux)
+ * **reqwest-rustls**: provides TLS support via the [rustls][rustls] library
+
+[rustls]: https://docs.rs/rustls
+[native-tls]: https://docs.rs/native-tls
+[cargo-features]: https://doc.rust-lang.org/stable/cargo/reference/manifest.html#the-features-section
+
 ## Testing
 
 ### Integration tests
@@ -29,7 +40,7 @@ cargo test --features test-mock
 
 This library includes additional interoperability tests against some of the most common registries.
 
-Those tests are not run by default as they required network access and registry credentials.
+Those tests are not run by default as they require network access and registry credentials.
 
 They are gated behind a dedicated "test-net" feature and can be run as:
 ```


### PR DESCRIPTION
This exposes two underlying TLS feature flags from reqwest, allowing
consumers to pick openssl (default) or rustls implementation.

Closes https://github.com/camallo/dkregistry-rs/pull/86 (superseded).