### PR TITLE
cargo: bump minor field after API changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dkregistry"
-version = "0.2.2-alpha.0"
+version = "0.3.0-alpha.0"
 authors = ["Luca Bruno <lucab@debian.org>", "Stefan Junker <sjunker@redhat.com>"]
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/dkregistry"


### PR DESCRIPTION
This bumps the minor version component, as there are been several API
changes since previous release.