### PR TITLE
v2: add `Send` bound to most of the API

### DIFF
--- a/examples/checkregistry.rs
+++ b/examples/checkregistry.rs
@@ -18,7 +18,7 @@ fn main() {
     };
 }
 
-fn run(host: &str) -> Result<bool, boxed::Box<error::Error>> {
+fn run(host: &str) -> Result<bool, boxed::Box<dyn error::Error>> {
     let mut runtime = Runtime::new()?;
     let dclient = try!(dkregistry::v2::Client::configure()
         .registry(host)
@@ -27,9 +27,10 @@ fn run(host: &str) -> Result<bool, boxed::Box<error::Error>> {
     let futcheck = dclient.is_v2_supported();
 
     let supported = runtime.block_on(futcheck)?;
-    match supported {
-        false => println!("{} does NOT support v2", host),
-        true => println!("{} supports v2", host),
+    if supported {
+        println!("{} supports v2", host);
+    } else {
+        println!("{} does NOT support v2", host);
     }
     Ok(supported)
 }

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -66,7 +66,7 @@ fn run(
     version: &str,
     user: Option<String>,
     passwd: Option<String>,
-) -> Result<(), boxed::Box<error::Error>> {
+) -> Result<(), boxed::Box<dyn error::Error>> {
     env_logger::Builder::new()
         .filter(Some("dkregistry"), log::LevelFilter::Trace)
         .filter(Some("trace"), log::LevelFilter::Trace)
@@ -93,7 +93,7 @@ fn run(
                 })
         })
         .and_then(|(dclient, manifest_kind)| {
-            let image = image.clone();
+            let image = image.to_owned();
             dclient.get_manifest(&image, &version).and_then(
                 move |manifest_body| match manifest_kind {
                     dkregistry::mediatypes::MediaTypes::ManifestV2S1Signed => {
@@ -117,7 +117,7 @@ fn run(
             )
         })
         .and_then(|(dclient, layers)| {
-            let image = image.clone();
+            let image = image.to_owned();
 
             println!("{} -> got {} layer(s)", &image, layers.len(),);
 
@@ -147,7 +147,6 @@ fn run(
     let can_path = path.canonicalize().unwrap();
 
     println!("Unpacking layers to {:?}", &can_path);
-    let r = render::unpack(&blobs, &can_path).unwrap();
-
-    Ok(r)
+    render::unpack(&blobs, &can_path)?;
+    Ok(())
 }

--- a/examples/login.rs
+++ b/examples/login.rs
@@ -42,7 +42,7 @@ fn run(
     user: Option<String>,
     passwd: Option<String>,
     login_scope: String,
-) -> Result<(), boxed::Box<error::Error>> {
+) -> Result<(), boxed::Box<dyn error::Error>> {
     env_logger::Builder::new()
         .filter(Some("dkregistry"), log::LevelFilter::Trace)
         .filter(Some("trace"), log::LevelFilter::Trace)

--- a/examples/tags.rs
+++ b/examples/tags.rs
@@ -43,7 +43,7 @@ fn run(
     user: Option<String>,
     passwd: Option<String>,
     image: &str,
-) -> Result<(), boxed::Box<error::Error>> {
+) -> Result<(), boxed::Box<dyn error::Error>> {
     env_logger::Builder::new()
         .filter(Some("dkregistry"), log::LevelFilter::Trace)
         .filter(Some("trace"), log::LevelFilter::Trace)

--- a/examples/trace.rs
+++ b/examples/trace.rs
@@ -57,7 +57,7 @@ fn run(
     dkr_ref: &reference::Reference,
     user: Option<String>,
     passwd: Option<String>,
-) -> Result<(), boxed::Box<error::Error>> {
+) -> Result<(), boxed::Box<dyn error::Error>> {
     env_logger::Builder::new()
         .filter(Some("dkregistry"), log::LevelFilter::Trace)
         .filter(Some("trace"), log::LevelFilter::Trace)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ use std::collections::HashMap;
 use std::io::Read;
 
 /// Default User-Agent client identity.
-pub static USER_AGENT: &'static str = "camallo-dkregistry/0.0";
+pub static USER_AGENT: &str = "camallo-dkregistry/0.0";
 
 /// Get registry credentials from a JSON config reader.
 ///

--- a/src/mediatypes.rs
+++ b/src/mediatypes.rs
@@ -5,7 +5,8 @@ use futures;
 use mime;
 use strum::EnumProperty;
 
-pub type FutureMediaType = Box<futures::Future<Item = Option<MediaTypes>, Error = Error> + Send>;
+pub type FutureMediaType =
+    Box<dyn futures::Future<Item = Option<MediaTypes>, Error = Error> + Send>;
 
 // For schema1 types, see https://docs.docker.com/registry/spec/manifest-v2-1/
 // For schema2 types, see https://docs.docker.com/registry/spec/manifest-v2-2/

--- a/src/mediatypes.rs
+++ b/src/mediatypes.rs
@@ -5,7 +5,7 @@ use futures;
 use mime;
 use strum::EnumProperty;
 
-pub type FutureMediaType = Box<futures::Future<Item = Option<MediaTypes>, Error = Error>>;
+pub type FutureMediaType = Box<futures::Future<Item = Option<MediaTypes>, Error = Error> + Send>;
 
 // For schema1 types, see https://docs.docker.com/registry/spec/manifest-v2-1/
 // For schema2 types, see https://docs.docker.com/registry/spec/manifest-v2-2/

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -172,7 +172,7 @@ fn parse_url(input: &str) -> Result<Reference, Error> {
     // Take image name and extract tag or digest-ref, if any.
     let last = components
         .pop_back()
-        .ok_or(Error::from("missing image name"))?;
+        .ok_or_else(|| Error::from("missing image name"))?;
     let (image_name, version) = match (last.rfind('@'), last.rfind(':')) {
         (Some(i), _) | (None, Some(i)) => {
             let s = last.split_at(i);
@@ -193,7 +193,7 @@ fn parse_url(input: &str) -> Result<Reference, Error> {
     // according to regex at https://docs.docker.com/registry/spec/api/#overview.
     let first = components
         .pop_front()
-        .ok_or(Error::from("missing image name"))?;
+        .ok_or_else(|| Error::from("missing image name"))?;
     let path_re = regex::Regex::new("^[a-z0-9]+(?:[._-][a-z0-9]+)*$")?;
     let registry = if path_re.is_match(&first) {
         components.push_front(first);

--- a/src/v2/auth.rs
+++ b/src/v2/auth.rs
@@ -3,7 +3,7 @@ use reqwest::{StatusCode, Url};
 use v2::*;
 
 /// Convenience alias for future `TokenAuth` result.
-pub type FutureTokenAuth = Box<Future<Item = TokenAuth, Error = Error> + Send>;
+pub type FutureTokenAuth = Box<dyn Future<Item = TokenAuth, Error = Error> + Send>;
 
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct TokenAuth {
@@ -19,7 +19,7 @@ impl TokenAuth {
     }
 }
 
-type FutureString = Box<Future<Item = String, Error = self::Error> + Send>;
+type FutureString = Box<dyn Future<Item = String, Error = self::Error> + Send>;
 
 impl Client {
     fn get_token_provider(&self) -> FutureString {

--- a/src/v2/auth.rs
+++ b/src/v2/auth.rs
@@ -3,7 +3,7 @@ use reqwest::{StatusCode, Url};
 use v2::*;
 
 /// Convenience alias for future `TokenAuth` result.
-pub type FutureTokenAuth = Box<Future<Item = TokenAuth, Error = Error> + 'static>;
+pub type FutureTokenAuth = Box<Future<Item = TokenAuth, Error = Error> + Send>;
 
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct TokenAuth {
@@ -19,7 +19,7 @@ impl TokenAuth {
     }
 }
 
-type FutureString = Box<Future<Item = String, Error = self::Error>>;
+type FutureString = Box<Future<Item = String, Error = self::Error> + Send>;
 
 impl Client {
     fn get_token_provider(&self) -> FutureString {

--- a/src/v2/blobs.rs
+++ b/src/v2/blobs.rs
@@ -4,7 +4,7 @@ use reqwest::StatusCode;
 use v2::*;
 
 /// Convenience alias for future binary blob.
-pub type FutureBlob = Box<futures::Future<Item = Vec<u8>, Error = Error> + Send>;
+pub type FutureBlob = Box<dyn futures::Future<Item = Vec<u8>, Error = Error> + Send>;
 
 impl Client {
     /// Check if a blob exists.

--- a/src/v2/blobs.rs
+++ b/src/v2/blobs.rs
@@ -4,7 +4,7 @@ use reqwest::StatusCode;
 use v2::*;
 
 /// Convenience alias for future binary blob.
-pub type FutureBlob = Box<futures::Future<Item = Vec<u8>, Error = Error>>;
+pub type FutureBlob = Box<futures::Future<Item = Vec<u8>, Error = Error> + Send>;
 
 impl Client {
     /// Check if a blob exists.

--- a/src/v2/catalog.rs
+++ b/src/v2/catalog.rs
@@ -5,7 +5,7 @@ use serde_json;
 use v2;
 
 /// Convenience alias for a stream of `String` repos.
-pub type StreamCatalog = Box<futures::Stream<Item = String, Error = Error>>;
+pub type StreamCatalog = Box<dyn futures::Stream<Item = String, Error = Error>>;
 
 #[derive(Debug, Default, Deserialize, Serialize)]
 struct Catalog {

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -65,13 +65,14 @@ pub struct Client {
 }
 
 /// Convenience alias for a future boolean result.
-pub type FutureBool = Box<Future<Item = bool, Error = Error> + Send>;
+pub type FutureBool = Box<dyn Future<Item = bool, Error = Error> + Send>;
 
 /// Convenience alias for a future manifest blob.
-pub type FutureManifest = Box<Future<Item = Vec<u8>, Error = Error> + Send>;
+pub type FutureManifest = Box<dyn Future<Item = Vec<u8>, Error = Error> + Send>;
 
 /// Convenience alias for a future manifest blob and ref.
-pub type FutureManifestAndRef = Box<Future<Item = (Vec<u8>, Option<String>), Error = Error> + Send>;
+pub type FutureManifestAndRef =
+    Box<dyn Future<Item = (Vec<u8>, Option<String>), Error = Error> + Send>;
 
 impl Client {
     pub fn configure() -> Config {

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -65,13 +65,13 @@ pub struct Client {
 }
 
 /// Convenience alias for a future boolean result.
-pub type FutureBool = Box<Future<Item = bool, Error = Error>>;
+pub type FutureBool = Box<Future<Item = bool, Error = Error> + Send>;
 
 /// Convenience alias for a future manifest blob.
-pub type FutureManifest = Box<Future<Item = Vec<u8>, Error = Error>>;
+pub type FutureManifest = Box<Future<Item = Vec<u8>, Error = Error> + Send>;
 
 /// Convenience alias for a future manifest blob and ref.
-pub type FutureManifestAndRef = Box<Future<Item = (Vec<u8>, Option<String>), Error = Error>>;
+pub type FutureManifestAndRef = Box<Future<Item = (Vec<u8>, Option<String>), Error = Error> + Send>;
 
 impl Client {
     pub fn configure() -> Config {
@@ -79,7 +79,7 @@ impl Client {
     }
 
     /// Ensure remote registry supports v2 API.
-    pub fn ensure_v2_registry(self) -> impl Future<Item = Self, Error = Error> {
+    pub fn ensure_v2_registry(self) -> impl Future<Item = Self, Error = Error> + Send {
         self.is_v2_supported()
             .map(move |ok| (ok, self))
             .and_then(|(ok, client)| {

--- a/src/v2/tags.rs
+++ b/src/v2/tags.rs
@@ -3,7 +3,7 @@ use reqwest::{self, header, Url};
 use v2::*;
 
 /// Convenience alias for a stream of `String` tags.
-pub type StreamTags = Box<futures::Stream<Item = String, Error = Error> + Send>;
+pub type StreamTags = Box<dyn futures::Stream<Item = String, Error = Error> + Send>;
 
 /// A chunk of tags for an image.
 ///

--- a/src/v2/tags.rs
+++ b/src/v2/tags.rs
@@ -3,7 +3,7 @@ use reqwest::{self, header, Url};
 use v2::*;
 
 /// Convenience alias for a stream of `String` tags.
-pub type StreamTags = Box<futures::Stream<Item = String, Error = Error>>;
+pub type StreamTags = Box<futures::Stream<Item = String, Error = Error> + Send>;
 
 /// A chunk of tags for an image.
 ///


### PR DESCRIPTION
This is required for consumers who want to use these methods in a
multi-threaded program.

Along the way some error conversion had to be changed.