### PR TITLE
cargo: update release metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ upload-doc = false
 disable-publish = true
 disable-push = true
 pre-release-commit-message = "cargo: dkregistry release {{version}}"
-pro-release-commit-message = "cargo: version bump to {{version}}"
+pro-release-commit-message = "cargo: development version bump"
+tag-prefix = ""
 
 [dependencies]
 base64 = "0.11"


### PR DESCRIPTION
This updates cargo-release metadata, making sure we are using our
specific settings instead of the defaults.