### PR TITLE
Reuse reqwest::Client

### DIFF
--- a/src/v2/auth.rs
+++ b/src/v2/auth.rs
@@ -29,7 +29,7 @@ impl Client {
         };
 
         let r = self
-            .build_reqwest(reqwest::Client::new().get(url.clone()))
+            .build_reqwest(Method::GET, url.clone())
             .send()
             .map_err(|e| Error::from(format!("{}", e)))
             .await?;
@@ -82,7 +82,7 @@ impl Client {
         })?;
 
         let auth_req = {
-            let auth_req = subclient.build_reqwest(reqwest::Client::new().get(url));
+            let auth_req = subclient.build_reqwest(Method::GET, url);
             if let Some(creds) = creds {
                 auth_req.basic_auth(creds.0, Some(creds.1))
             } else {
@@ -133,7 +133,7 @@ impl Client {
             }
         };
 
-        let req = self.build_reqwest(reqwest::Client::new().get(url.clone()));
+        let req = self.build_reqwest(Method::GET, url.clone());
         let req = if let Some(t) = token {
             req.bearer_auth(t)
         } else {

--- a/src/v2/blobs.rs
+++ b/src/v2/blobs.rs
@@ -1,7 +1,7 @@
 use crate::errors::{Error, Result};
 use crate::v2::*;
 use reqwest;
-use reqwest::StatusCode;
+use reqwest::{Method, StatusCode};
 
 impl Client {
     /// Check if a blob exists.
@@ -19,10 +19,7 @@ impl Client {
             }
         };
 
-        let res = self
-            .build_reqwest(reqwest::Client::new().head(url))
-            .send()
-            .await?;
+        let res = self.build_reqwest(Method::HEAD, url.clone()).send().await?;
 
         trace!("Blob HEAD status: {:?}", res.status());
 
@@ -41,10 +38,7 @@ impl Client {
             let url = reqwest::Url::parse(&ep)
                 .map_err(|e| Error::from(format!("failed to parse url from string: {}", e)))?;
 
-            let res = self
-                .build_reqwest(reqwest::Client::new().get(url))
-                .send()
-                .await?;
+            let res = self.build_reqwest(Method::GET, url.clone()).send().await?;
 
             trace!("GET {} status: {}", res.url(), res.status());
             let status = res.status();

--- a/src/v2/catalog.rs
+++ b/src/v2/catalog.rs
@@ -3,7 +3,7 @@ use crate::v2;
 use async_stream::try_stream;
 use futures::stream::Stream;
 use futures::{self};
-use reqwest::{RequestBuilder, StatusCode};
+use reqwest::{Method, RequestBuilder, StatusCode};
 
 #[derive(Debug, Default, Deserialize, Serialize)]
 struct Catalog {
@@ -28,7 +28,7 @@ impl v2::Client {
         };
 
         try_stream! {
-            let req = self.build_reqwest(reqwest::Client::new().get(url?));
+            let req = self.build_reqwest(Method::GET, url?);
 
             let catalog = fetch_catalog(req).await?;
 

--- a/src/v2/config.rs
+++ b/src/v2/config.rs
@@ -81,12 +81,15 @@ impl Config {
                 p.unwrap_or_else(|| "".into()),
             )),
         };
+        let client = reqwest::ClientBuilder::new().build()?;
+
         let c = Client {
             base_url: base,
             credentials: creds,
             index: self.index,
             user_agent: self.user_agent,
             token: None,
+            client: client,
         };
         Ok(c)
     }

--- a/src/v2/manifest/manifest_schema2.rs
+++ b/src/v2/manifest/manifest_schema2.rs
@@ -1,4 +1,5 @@
 use crate::errors::{Error, Result};
+use reqwest::Method;
 
 /// Manifest version 2 schema 2.
 ///
@@ -111,7 +112,7 @@ impl ManifestSchema2Spec {
         };
 
         let r = client
-            .build_reqwest(reqwest::Client::new().get(url.clone()))
+            .build_reqwest(Method::GET, url.clone())
             .send()
             .await?;
 

--- a/src/v2/manifest/mod.rs
+++ b/src/v2/manifest/mod.rs
@@ -39,11 +39,8 @@ impl Client {
         let client_spare0 = self.clone();
 
         let res = self
-            .build_reqwest(
-                reqwest::Client::new()
-                    .get(url.clone())
-                    .headers(accept_headers),
-            )
+            .build_reqwest(Method::GET, url.clone())
+            .headers(accept_headers)
             .send()
             .await?;
 
@@ -123,7 +120,8 @@ impl Client {
         let accept_headers = build_accept_headers();
 
         let res = self
-            .build_reqwest(reqwest::Client::new().head(url).headers(accept_headers))
+            .build_reqwest(Method::HEAD, url)
+            .headers(accept_headers)
             .send()
             .await?;
 
@@ -196,7 +194,7 @@ impl Client {
         trace!("HEAD {:?}", url);
 
         let r = self
-            .build_reqwest(reqwest::Client::new().get(url.clone()))
+            .build_reqwest(Method::GET, url.clone())
             .headers(accept_headers)
             .send()
             .await

--- a/src/v2/tags.rs
+++ b/src/v2/tags.rs
@@ -57,7 +57,7 @@ impl Client {
         let url = Url::parse(&url_paginated).map_err(|e| Error::from(format!("{}", e)))?;
 
         let resp = self
-            .build_reqwest(reqwest::Client::new().get(url.clone()))
+            .build_reqwest(Method::GET, url.clone())
             .header(header::ACCEPT, "application/json")
             .send()
             .await?


### PR DESCRIPTION
This commit ensures reqwest client is created once and reused across calls