### PR TITLE
Use thiserror for error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ tag-prefix = ""
 
 [dependencies]
 base64 = "0.12"
-error-chain = { version = "0.12", default-features = false }
 futures = "0.3"
 http = "0.2"
 libflate = "1.0"
@@ -41,6 +40,8 @@ tokio = "0.2"
 reqwest = { version = "0.10", default-features = false, features = ["json"] }
 sha2 = "^0.9.0"
 async-stream = "0.3"
+thiserror = "1.0.19"
+url = "2.1.1"
 
 [dev-dependencies]
 dirs = "3.0"

--- a/examples/image-labels.rs
+++ b/examples/image-labels.rs
@@ -70,10 +70,7 @@ async fn run(
     let version = dkr_ref.version();
 
     let dclient = client.authenticate(&[&login_scope]).await?;
-    let manifest = match dclient.get_manifest(&image, &version).await {
-        Ok(manifest) => Ok(manifest),
-        Err(e) => Err(format!("Got error {}", e)),
-    }?;
+    let manifest = dclient.get_manifest(&image, &version).await?;
 
     if let Manifest::S1Signed(s1s) = manifest {
         let labels = s1s.get_labels(0);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,17 +1,68 @@
-//! Error chains, types and traits.
+//! Defines root error type
 
-error_chain! {
-    foreign_links {
-        Base64Decode(base64::DecodeError);
-        HeaderInvalid(http::header::InvalidHeaderValue);
-        HeaderParse(http::header::ToStrError);
-        Hyper(http::Error);
-        Io(std::io::Error);
-        Json(serde_json::Error);
-        Regex(regex::Error);
-        Reqwest(reqwest::Error);
-        UriParse(http::uri::InvalidUri);
-        Utf8Parse(std::string::FromUtf8Error);
-        StrumParse(strum::ParseError);
+#[non_exhaustive]
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("base64 decode error")]
+    Base64Decode(#[from] base64::DecodeError),
+    #[error("header parse error")]
+    HeaderParse(#[from] http::header::ToStrError),
+    #[error("json error")]
+    Json(#[from] serde_json::Error),
+    #[error("http transport error")]
+    Reqwest(#[from] reqwest::Error),
+    #[error("URI parse error")]
+    Uri(#[from] url::ParseError),
+    #[error("input is not UTF-8")]
+    Ut8Parse(#[from] std::string::FromUtf8Error),
+    #[error("strum error")]
+    StrumParse(#[from] strum::ParseError),
+    #[error("authentication information missing for index {0}")]
+    AuthInfoMissing(String),
+    #[error("unknown media type {0:?}")]
+    UnknownMimeType(mime::Mime),
+    #[error("unknown media type {0:?}")]
+    UnsupportedMediaType(crate::mediatypes::MediaTypes),
+    #[error("mime parse error")]
+    MimeParse(#[from] mime::FromStrError),
+    #[error("missing authentication header {0}")]
+    MissingAuthHeader(&'static str),
+    #[error("unexpected HTTP status {0}")]
+    UnexpectedHttpStatus(http::StatusCode),
+    #[error("invalid auth token '{0}'")]
+    InvalidAuthToken(String),
+    #[error("API V2 not supported")]
+    V2NotSupported,
+    #[error("obtained token is invalid")]
+    LoginReturnedBadToken,
+    #[error("www-authenticate header parse error")]
+    Www(#[from] crate::v2::WwwHeaderParseError),
+    #[error("request failed with status {status} and body of size {len}: {}", String::from_utf8_lossy(&body))]
+    Client {
+        status: http::StatusCode,
+        len: usize,
+        body: Vec<u8>,
+    },
+    #[error("content digest error")]
+    ContentDigestParse(#[from] crate::v2::ContentDigestError),
+    #[error("no header Content-Type given and no workaround to apply")]
+    MediaTypeSniff,
+    #[error("manifest error")]
+    Manifest(#[from] crate::v2::manifest::ManifestError),
+    #[error("reference is invalid")]
+    ReferenceParse(#[from] crate::reference::ReferenceParseError),
+    #[error("requested operation requires that credentials are available")]
+    NoCredentials
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_error_bounds() {
+        fn check_bounds<T: Send + Sync + 'static>() {}
+        check_bounds::<Error>();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,8 +36,6 @@
 #[macro_use]
 extern crate serde;
 #[macro_use]
-extern crate error_chain;
-#[macro_use]
 extern crate log;
 #[macro_use]
 extern crate strum_macros;
@@ -48,9 +46,10 @@ pub mod reference;
 pub mod render;
 pub mod v2;
 
-use errors::Result;
+use errors::{Result, Error};
 use std::collections::HashMap;
 use std::io::Read;
+
 
 /// Default User-Agent client identity.
 pub static USER_AGENT: &str = "camallo-dkregistry/0.0";
@@ -71,7 +70,7 @@ pub fn get_credentials<T: Read>(
     };
     let auth = match map.auths.get(real_index) {
         Some(x) => base64::decode(x.auth.as_str())?,
-        None => bail!("no auth for index {}", real_index),
+        None => return Err(Error::AuthInfoMissing(real_index.to_string())),
     };
     let s = String::from_utf8(auth)?;
     let creds: Vec<&str> = s.splitn(2, ':').collect();

--- a/src/mediatypes.rs
+++ b/src/mediatypes.rs
@@ -1,6 +1,6 @@
 //! Media-types for API objects.
 
-use crate::errors::{Error, Result};
+use crate::errors::{Result};
 use mime;
 use strum::EnumProperty;
 
@@ -62,13 +62,13 @@ impl MediaTypes {
                     }
                     ("vnd.docker.image.rootfs.diff.tar.gzip", _) => Ok(MediaTypes::ImageLayerTgz),
                     ("vnd.docker.container.image.v1", "json") => Ok(MediaTypes::ContainerConfigV1),
-                    _ => bail!("unknown mediatype {:?}", mtype),
+                    _ => return Err(crate::Error::UnknownMimeType(mtype.clone())),
                 }
             }
-            _ => bail!("unknown mediatype {:?}", mtype),
+            _ => return Err(crate::Error::UnknownMimeType(mtype.clone())),
         }
     }
-    pub fn to_mime(&self) -> Result<mime::Mime> {
+    pub fn to_mime(&self) -> mime::Mime {
         match self {
             &MediaTypes::ApplicationJson => Ok(mime::APPLICATION_JSON),
             ref m => {
@@ -79,6 +79,6 @@ impl MediaTypes {
                 }
             }
         }
-        .map_err(|e| Error::from(e.to_string()))
+        .expect("to_mime should be always successful")
     }
 }

--- a/src/v2/content_digest.rs
+++ b/src/v2/content_digest.rs
@@ -1,19 +1,31 @@
-use crate::errors::Result;
 /// Implements types and methods for content verification
 use sha2::{self, Digest};
 
 /// ContentDigest stores a digest and its DigestAlgorithm
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) struct ContentDigest {
+pub struct ContentDigest {
     digest: String,
     algorithm: DigestAlgorithm,
 }
 
 /// DigestAlgorithm declares the supported algorithms
 #[derive(Display, Clone, Debug, PartialEq, EnumString)]
-enum DigestAlgorithm {
+pub enum DigestAlgorithm {
     #[strum(to_string = "sha256")]
     Sha256,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ContentDigestError {
+    #[error("digest {0} does not have algorithm prefix")]
+    BadDigest(String),
+    #[error("unknown algorithm")]
+    AlgorithmUnknown(#[from] <DigestAlgorithm as std::str::FromStr>::Err),
+    #[error("verification failed: expected '{expected}', got '{got}'")]
+    Verify {
+        expected: ContentDigest,
+        got: ContentDigest,
+    },
 }
 
 impl ContentDigest {
@@ -22,15 +34,14 @@ impl ContentDigest {
     /// Success depends on
     /// - the string having a "algorithm:" prefix
     /// - the algorithm being supported by DigestAlgorithm
-    pub fn try_new(digest: String) -> Result<Self> {
+    pub fn try_new(digest: String) -> std::result::Result<Self, ContentDigestError> {
         let digest_split = digest.split(':').collect::<Vec<&str>>();
 
         if digest_split.len() != 2 {
-            return Err(format!("digest '{}' does not have an algorithm prefix", digest).into());
+            return Err(ContentDigestError::BadDigest(digest));
         }
 
-        let algorithm =
-            std::str::FromStr::from_str(digest_split[0]).map_err(|e| format!("{}", e))?;
+        let algorithm = std::str::FromStr::from_str(digest_split[0])?;
         Ok(ContentDigest {
             digest: digest_split[1].to_string(),
             algorithm,
@@ -40,17 +51,15 @@ impl ContentDigest {
     /// try_verify hashes the input slice and compares it with the digest stored in this instance
     ///
     /// Success depends on the result of the comparison
-    pub fn try_verify(&self, input: &[u8]) -> Result<()> {
+    pub fn try_verify(&self, input: &[u8]) -> std::result::Result<(), ContentDigestError> {
         let hash = self.algorithm.hash(input);
         let layer_digest = Self::try_new(hash)?;
 
         if self != &layer_digest {
-            return Err(format!(
-                "content verification failed. expected '{}', got '{}'",
-                self.to_owned(),
-                layer_digest.to_owned()
-            )
-            .into());
+            return Err(ContentDigestError::Verify {
+                expected: self.clone(),
+                got: layer_digest.clone(),
+            });
         }
 
         trace!("content verification succeeded for '{}'", &layer_digest);
@@ -78,7 +87,7 @@ impl DigestAlgorithm {
 #[cfg(test)]
 mod tests {
     use super::*;
-    type Fallible<T> = Result<T>;
+    type Fallible<T> = Result<T, crate::Error>;
 
     #[test]
     fn try_new_succeeds_with_correct_digest() -> Fallible<()> {
@@ -92,22 +101,19 @@ mod tests {
     }
 
     #[test]
-    fn try_new_succeeds_with_incorrect_digest() -> Fallible<()> {
+    fn try_new_succeeds_with_incorrect_digest() {
         for incorrect_digest in &[
             "invalid",
             "invalid:",
             "invalid:0000000000000000000000000000000000000000000000000000000000000000",
         ] {
             if ContentDigest::try_new(incorrect_digest.to_string()).is_ok() {
-                return Err(format!(
+                panic!(
                     "expected try_new to fail for incorrect digest {}",
                     incorrect_digest
-                )
-                .into());
+                );
             }
         }
-
-        Ok(())
     }
 
     #[test]
@@ -115,7 +121,9 @@ mod tests {
         let blob: &[u8] = b"somecontent";
         let digest = DigestAlgorithm::Sha256.hash(&blob);
 
-        ContentDigest::try_new(digest)?.try_verify(&blob)
+        ContentDigest::try_new(digest)?
+            .try_verify(&blob)
+            .map_err(Into::into)
     }
 
     #[test]
@@ -128,9 +136,8 @@ mod tests {
             .try_verify(&different_blob)
             .is_ok()
         {
-            return Err("expected try_verify to fail for a different blob".into());
+            panic!("expected try_verify to fail for a different blob");
         }
-
         Ok(())
     }
 }

--- a/src/v2/manifest/manifest_schema1.rs
+++ b/src/v2/manifest/manifest_schema1.rs
@@ -53,7 +53,7 @@ impl ManifestSchema1Signed {
     /// Get a collection of all image labels stored in the history array of this manifest.
     ///
     /// Note that for this manifest type any `layer` beyond 0 probably returns None.
-    pub fn get_labels(&self, layer: usize) -> Option<(HashMap<String, String>)> {
+    pub fn get_labels(&self, layer: usize) -> Option<HashMap<String, String>> {
         Some(
             serde_json::from_str::<serde_json::Value>(&self.history.get(layer)?.v1_compat)
                 .ok()?

--- a/src/v2/manifest/manifest_schema2.rs
+++ b/src/v2/manifest/manifest_schema2.rs
@@ -100,15 +100,7 @@ impl ManifestSchema2Spec {
                 repo,
                 self.config.digest
             );
-            match reqwest::Url::parse(&ep) {
-                Ok(url) => url,
-                Err(e) => {
-                    return Err(Error::from(format!(
-                        "failed to parse url from string '{}': {}",
-                        ep, e
-                    )));
-                }
-            }
+            reqwest::Url::parse(&ep)?
         };
 
         let r = client
@@ -120,7 +112,7 @@ impl ManifestSchema2Spec {
         trace!("GET {:?}: {}", url, &status);
 
         if !status.is_success() {
-            return Err(format!("wrong HTTP status '{}'", status).into());
+            return Err(Error::UnexpectedHttpStatus(status));
         }
 
         let config_blob = r.json::<ConfigBlob>().await?;

--- a/tests/mock/base_client.rs
+++ b/tests/mock/base_client.rs
@@ -30,7 +30,7 @@ fn test_base_no_insecure() {
 
     // This relies on the fact that mockito is HTTP-only and
     // trying to speak TLS to it results in garbage/errors.
-    runtime.block_on(futcheck).is_err();
+    runtime.block_on(futcheck).unwrap_err();
 
     mockito::reset();
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,9 +1,5 @@
 #[cfg(feature = "test-net")]
 mod net;
 
-#[cfg(feature = "test-net")]
-#[macro_use]
-extern crate error_chain;
-
 #[cfg(feature = "test-mock")]
 mod mock;

--- a/tests/net/quay_io/mod.rs
+++ b/tests/net/quay_io/mod.rs
@@ -286,9 +286,9 @@ fn test_quayio_auth_layer_blob() {
             .and_then(|manifest| {
                 let layers: Vec<String> = manifest.layers_digests(None)?;
                 let num_layers = layers.len();
-                ensure!(num_layers == 1, "layers length: {}", num_layers);
+                assert!(num_layers == 1, "layers length: {}", num_layers);
                 let digest = layers[0].clone();
-                ensure!(digest == layer0_sha, "layer0 digest: {}", digest);
+                assert!(digest == layer0_sha, "layer0 digest: {}", digest);
                 Ok(digest)
             })
             .unwrap();


### PR DESCRIPTION
# Motivation
 - `error-chain` generates Error type which is not `Sync`, so it is hard to use with many other libraries.
 - Libraries are encouraged to provide structured error details instead of just formatted message.
# Changes
 - `errors::Error` type is now plain enum, using `thiserror` for `Display` and `From` impls.
 - It is very large, but I don't think it is significant drawback.
 - Some functions return custom Error type (which is more convenient to use), but such types can be converted to `errors::Error`.
 - Unfortunately new approach does not play well with backtraces. I think this can be fixed if needed.
 - In several places I replaced `?` with `expect` because there should not be any errors in fact. 