### PR TITLE
Release 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dkregistry"
-version = "0.4.0-alpha.0"
+version = "0.4.0"
 authors = ["Luca Bruno <lucab@debian.org>", "Stefan Junker <sjunker@redhat.com>"]
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/dkregistry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dkregistry"
-version = "0.4.0"
+version = "0.4.1-alpha.0"
 authors = ["Luca Bruno <lucab@debian.org>", "Stefan Junker <sjunker@redhat.com>"]
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/dkregistry"


### PR DESCRIPTION
## [release-0.4.0](https://github.com/camallo/dkregistry-rs/compare/release-0.3.1...release-0.4.0) (2020-07-09)

* Reuse reqwest::Client [#152](https://github.com/camallo/dkregistry-rs/pull/152) ([vrutkovs](https://github.com/vrutkovs))
* v2/manifest: add a function to fetch content-digest for a tag [#148](https://github.com/camallo/dkregistry-rs/pull/148) ([vrutkovs](https://github.com/vrutkovs))
* travis: cache cargo [#134](https://github.com/camallo/dkregistry-rs/pull/134) ([steveeJ](https://github.com/steveeJ))
* Switch to Rust edition 2018 [#133](https://github.com/camallo/dkregistry-rs/pull/133) ([steveeJ](https://github.com/steveeJ))
* Release 0.3.1 [#130](https://github.com/camallo/dkregistry-rs/pull/130) ([steveeJ](https://github.com/steveeJ))

*(generated via `ghch --remote=upstream --from=release-0.3.1 --to=release-0.4.0 --format=markdown | grep -v dependabot`)*