### PR TITLE
Allow authentication without credentials for docker.io repo

### DIFF
--- a/src/v2/auth.rs
+++ b/src/v2/auth.rs
@@ -267,14 +267,12 @@ impl Client {
             authentication_header,
         )? {
             WwwAuthenticateHeaderContent::Basic(_) => {
-                let basic_auth = {
-                    let (user, password) =
-                        credentials.expect("cannot authenticate without credentials");
-                    BasicAuth {
+                let basic_auth = credentials
+                    .map(|(user, password)| BasicAuth {
                         user,
                         password: Some(password),
-                    }
-                };
+                    })
+                    .ok_or("cannot authenticate without credentials")?;
 
                 Auth::Basic(basic_auth)
             }

--- a/src/v2/auth.rs
+++ b/src/v2/auth.rs
@@ -35,7 +35,7 @@ impl BearerAuth {
     async fn try_from_header_content(
         client: Client,
         scopes: &[&str],
-        credentials: (String, String),
+        credentials: Option<(String, String)>,
         bearer_header_content: WwwAuthenticateHeaderContentBearer,
     ) -> Result<Self> {
         let auth_ep = bearer_header_content.auth_ep(scopes);
@@ -48,12 +48,16 @@ impl BearerAuth {
             ))
         })?;
 
-        let auth_req = Client {
-            auth: Some(Auth::Basic(BasicAuth {
-                user: credentials.0,
-                password: Some(credentials.1),
-            })),
-            ..client
+        let auth_req = {
+            Client {
+                auth: credentials.map(|(user, password)| {
+                    Auth::Basic(BasicAuth {
+                        user,
+                        password: Some(password),
+                    })
+                }),
+                ..client
+            }
         }
         .build_reqwest(Method::GET, url);
 
@@ -251,10 +255,7 @@ impl Client {
     ///
     /// If Bearer authentication is used the returned client will be authorized for the requested scopes.
     pub async fn authenticate(mut self, scopes: &[&str]) -> Result<Self> {
-        let credentials = self
-            .credentials
-            .clone()
-            .ok_or("cannot authenticate without credentials")?;
+        let credentials = self.credentials.clone();
 
         let client = Client {
             auth: None,
@@ -266,9 +267,13 @@ impl Client {
             authentication_header,
         )? {
             WwwAuthenticateHeaderContent::Basic(_) => {
-                let basic_auth = BasicAuth {
-                    user: credentials.0,
-                    password: Some(credentials.1),
+                let basic_auth = {
+                    let (user, password) =
+                        credentials.expect("cannot authenticate without credentials");
+                    BasicAuth {
+                        user,
+                        password: Some(password),
+                    }
                 };
 
                 Auth::Basic(basic_auth)

--- a/tests/net/docker_io/mod.rs
+++ b/tests/net/docker_io/mod.rs
@@ -64,7 +64,7 @@ fn test_dockerio_insecure() {
 }
 
 #[test]
-fn test_dockerio_unauthed() {
+fn test_dockerio_anonymous_auth() {
     let mut runtime = Runtime::new().unwrap();
     let image = "library/alpine";
     let version = "latest";

--- a/tests/net/docker_io/mod.rs
+++ b/tests/net/docker_io/mod.rs
@@ -62,3 +62,26 @@ fn test_dockerio_insecure() {
     let res = runtime.block_on(futcheck).unwrap();
     assert_eq!(res, true);
 }
+
+#[test]
+fn test_dockerio_unauthed() {
+    let mut runtime = Runtime::new().unwrap();
+    let image = "library/alpine";
+    let version = "latest";
+    let login_scope = format!("repository:{}:pull", image);
+    let scopes = vec![login_scope.as_str()];
+    let dclient_future = dkregistry::v2::Client::configure()
+        .registry(REGISTRY)
+        .insecure_registry(false)
+        .username(None)
+        .password(None)
+        .build()
+        .unwrap()
+        .authenticate(scopes.as_slice());
+
+    let dclient = runtime.block_on(dclient_future).unwrap();
+    let futcheck = dclient.get_manifest(image, version);
+
+    let res = runtime.block_on(futcheck);
+    assert_eq!(res.is_ok(), true);
+}


### PR DESCRIPTION
Before the refactor of the auth logic (5a4ec71136d3c70d3675f11719a0788cb28eea7f) we could pull from `docker.io` without credentials.

After the commit that behaviour has changed and we unfortunately need to provide valid credentials as otherwise we can't pull from Docker Hub.

This PR adds back support for pulling from Docker Hub