### PR TITLE
fix: support 'charset=utf-8' parameter for application/json mimetype

### DIFF
--- a/src/mediatypes.rs
+++ b/src/mediatypes.rs
@@ -18,7 +18,7 @@ pub enum MediaTypes {
         serialize = "application/vnd.docker.distribution.manifest.v1+prettyjws",
         to_string = "application/vnd.docker.distribution.manifest.v1+prettyjws",
 
-        // TODO(steveeJ) find a generic way to handle this form
+        // TODO(steveeJ) find a generic way to handle this form (see also ApplicationJson)
         serialize = "application/vnd.docker.distribution.manifest.v1+prettyjws; charset=utf-8",
     )]
     #[strum(props(Sub = "vnd.docker.distribution.manifest.v1+prettyjws"))]
@@ -40,7 +40,11 @@ pub enum MediaTypes {
     #[strum(props(Sub = "vnd.docker.container.image.v1+json"))]
     ContainerConfigV1,
     /// Generic JSON
-    #[strum(serialize = "application/json")]
+    #[strum(
+        serialize = "application/json",
+        to_string = "application/json",
+        serialize = "application/json; charset=utf-8",
+    )]
     #[strum(props(Sub = "json"))]
     ApplicationJson,
 }


### PR DESCRIPTION
Seeing the charset param for application/json content-type present in the wild (in this case Azure CR), which was causing a strum error to be thrown when trying to construct the `MediaTypes` enum from the header.

Following the existing solution above in the enum this simply adds a second 'serialize' attribute param to the ApplicationJson variant.

It is noted that @steveeJ added a 'TODO' to find a generic way to handle these on the existing usage, but this is not addressed in this bugfix.