### PR TITLE
fix: correctly separate multiple scopes with '&'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ dirs = "3.0"
 env_logger = "0.7"
 mockito = "0.27"
 spectral = "0.6"
+test-case = "1.0.0"
 tokio = { version = "0.2", features = ["macros"] }
 
 [features]


### PR DESCRIPTION
was generating invalid query strings with multiple scopes, eg:

```
.authenticate(&["repository:foo:pull", "repository:bar:pull"])
```
is serialised as:
```
?service=...&scope=repository:foo:pullscope=repository:bar:pull
```

note the missing '&' between pull and scope.