### PR TITLE
client: add method to evaluate authorization status

### DIFF
--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -68,7 +68,7 @@ impl Client {
     /// Ensure remote registry supports v2 API.
     pub async fn ensure_v2_registry(self) -> Result<Self> {
         if !self.is_v2_supported().await? {
-            return Err(Error::V2NotSupported)
+            Err(Error::V2NotSupported)
         } else {
             Ok(self)
         }


### PR DESCRIPTION
This method can be used to evaluate if a client instance is authorized
to at least call the `v2` endpoint on the remote registry.