### PR TITLE
cargo: update release metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,12 @@ exclude = [
 edition = "2018"
 
 [package.metadata.release]
-sign-commit = true
-upload-doc = false
 disable-publish = true
 disable-push = true
+post-release-commit-message = "cargo: development version bump"
 pre-release-commit-message = "cargo: dkregistry release {{version}}"
-pro-release-commit-message = "cargo: development version bump"
-tag-prefix = ""
+sign-commit = true
+tag-message = "dkregistry v{{version}}"
 
 [dependencies]
 base64 = "0.13"


### PR DESCRIPTION
This updates the metadata for cargo-release, in order to work
with latest release.
Notably, tags now have a `v` prefix-separator by default (see
https://github.com/sunng87/cargo-release#156).