### PR TITLE
Cargo: enable tag signing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ disable-push = true
 post-release-commit-message = "cargo: development version bump"
 pre-release-commit-message = "cargo: dkregistry release {{version}}"
 sign-commit = true
+sign-tag = true
 tag-message = "dkregistry v{{version}}"
 
 [dependencies]


### PR DESCRIPTION
This won't be implied with `sign-commit` in the next minor release of
`cargo release`, so setting it explicitly to retain the current
behavior.

Closes #183 