### PR TITLE
Cargo: downgrade async-stream for compatibility with rust 1.43

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rust:
   - stable
   - beta
   - nightly
+  - 1.43.1
 cache: cargo
 matrix:
   allow_failures:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ tar = "0.4"
 tokio = "0.2"
 reqwest = { version = "0.10", default-features = false, features = ["json"] }
 sha2 = "^0.9.0"
-async-stream = "0.3"
+async-stream = "0.2"
 thiserror = "1.0.19"
 url = "2.1.1"
 


### PR DESCRIPTION
I didn't manage to change this dependency from the consumer of dkregistry so I'm resorting to downgrading it here.

Includes #190.