### PR TITLE
travis: run with rust 1.43.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rust:
   - stable
   - beta
   - nightly
+  - 1.43.1
 cache: cargo
 matrix:
   allow_failures:


### PR DESCRIPTION
This is to ensure that dkregisty-rs doesn't break compatibility with
the [rhel8/rust-toolset container][0].

[0]: https://catalog.redhat.com/software/containers/rhel8/rust-toolset/5b9c6aa85a134643ef2ecc63