### PR TITLE
Update to tokio 1.0 and reqwest 0.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rust:
   - stable
   - beta
   - nightly
-  - 1.43.1
+  - 1.45.0
 cache: cargo
 matrix:
   allow_failures:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ serde_ignored = "0.1"
 strum = "0.20"
 strum_macros = "0.20"
 tar = "0.4"
-tokio = "0.2"
-reqwest = { version = "0.10", default-features = false, features = ["json"] }
+tokio = "1.0"
+reqwest = { version = "0.11", default-features = false, features = ["json"] }
 sha2 = "^0.9.0"
 async-stream = "0.2"
 thiserror = "1.0.19"
@@ -49,7 +49,7 @@ env_logger = "0.8"
 mockito = "0.29"
 spectral = "0.6"
 test-case = "1.0.0"
-tokio = { version = "0.2", features = ["macros"] }
+tokio = { version = "1.0", features = ["full"] }
 
 [features]
 default = ["reqwest-default-tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,8 @@ env_logger = "0.8"
 mockito = "0.29"
 spectral = "0.6"
 test-case = "1.0.0"
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
+
 
 [features]
 default = ["reqwest-default-tls"]


### PR DESCRIPTION
All blockers seem to be gone, so tokio can be updated!
ref: https://github.com/camallo/dkregistry-rs/pull/188

@steveeJ 