### PR TITLE
Send HEAD, not GET, when checking manifest existence

### DIFF
--- a/src/v2/manifest/mod.rs
+++ b/src/v2/manifest/mod.rs
@@ -164,7 +164,7 @@ impl Client {
         trace!("HEAD {:?}", url);
 
         let r = self
-            .build_reqwest(Method::GET, url.clone())
+            .build_reqwest(Method::HEAD, url.clone())
             .headers(accept_headers)
             .send()
             .await


### PR DESCRIPTION
I've updated the `has_manifest` function to send a HEAD request, as the response body isn't used.