### PR TITLE
make Www-Authentication header parsing case-insensitive

### DIFF
--- a/src/v2/auth.rs
+++ b/src/v2/auth.rs
@@ -141,9 +141,7 @@ impl WwwAuthenticateHeaderContent {
                 .iter()
                 .filter_map(|capture| {
                     match (
-                        capture
-                            .name("key")
-                            .map(|n| n.as_str().to_lowercase()),
+                        capture.name("key").map(|n| n.as_str().to_lowercase()),
                         capture.name("value").map(|n| n.as_str().to_string()),
                     ) {
                         (Some(key), Some(value)) => Some(format!(

--- a/src/v2/auth.rs
+++ b/src/v2/auth.rs
@@ -342,8 +342,8 @@ mod tests {
                 r#"Bearer REALM="{}",SERVICE="{}",SCOPE="{}""#,
                 realm, service, scope
             )).unwrap()
-        ] {
-            let content = WwwAuthenticateHeaderContent::from_www_authentication_header(header_value)?;
+        ].iter() {
+            let content = WwwAuthenticateHeaderContent::from_www_authentication_header(header_value.to_owned())?;
 
         assert_eq!(
             WwwAuthenticateHeaderContent::Bearer(WwwAuthenticateHeaderContentBearer {
@@ -376,9 +376,9 @@ mod tests {
             HeaderValue::from_str(&format!(r#"BASIC realm="{}""#, realm)).unwrap(),
             HeaderValue::from_str(&format!(r#"Basic Realm="{}""#, realm)).unwrap(),
             HeaderValue::from_str(&format!(r#"Basic REALM="{}""#, realm)).unwrap()
-        ] {
+        ].iter() {
             let content =
-                WwwAuthenticateHeaderContent::from_www_authentication_header(header_value)?;
+                WwwAuthenticateHeaderContent::from_www_authentication_header(header_value.to_owned())?;
 
             assert_eq!(
                 WwwAuthenticateHeaderContent::Basic(WwwAuthenticateHeaderContentBasic {

--- a/src/v2/auth.rs
+++ b/src/v2/auth.rs
@@ -142,7 +142,9 @@ impl WwwAuthenticateHeaderContent {
                 .iter()
                 .filter_map(|capture| {
                     match (
-                        capture.name("key").map(|n| n.as_str().to_lowercase().to_string()),
+                        capture
+                            .name("key")
+                            .map(|n| n.as_str().to_lowercase().to_string()),
                         capture.name("value").map(|n| n.as_str().to_string()),
                     ) {
                         (Some(key), Some(value)) => Some(format!(
@@ -325,34 +327,43 @@ mod tests {
             HeaderValue::from_str(&format!(
                 r#"Bearer realm="{}",service="{}",scope="{}""#,
                 realm, service, scope
-            )).unwrap(),
+            ))
+            .unwrap(),
             HeaderValue::from_str(&format!(
                 r#"bearer realm="{}",service="{}",scope="{}""#,
                 realm, service, scope
-            )).unwrap(),
+            ))
+            .unwrap(),
             HeaderValue::from_str(&format!(
                 r#"BEARER realm="{}",service="{}",scope="{}""#,
                 realm, service, scope
-            )).unwrap(),
+            ))
+            .unwrap(),
             HeaderValue::from_str(&format!(
                 r#"Bearer Realm="{}",Service="{}",Scope="{}""#,
                 realm, service, scope
-            )).unwrap(),
+            ))
+            .unwrap(),
             HeaderValue::from_str(&format!(
                 r#"Bearer REALM="{}",SERVICE="{}",SCOPE="{}""#,
                 realm, service, scope
-            )).unwrap()
-        ].iter() {
-            let content = WwwAuthenticateHeaderContent::from_www_authentication_header(header_value.to_owned())?;
+            ))
+            .unwrap(),
+        ]
+        .iter()
+        {
+            let content = WwwAuthenticateHeaderContent::from_www_authentication_header(
+                header_value.to_owned(),
+            )?;
 
-        assert_eq!(
-            WwwAuthenticateHeaderContent::Bearer(WwwAuthenticateHeaderContentBearer {
-                realm: realm.to_string(),
-                service: Some(service.to_string()),
-                scope: Some(scope.to_string()),
-            }),
-            content
-        );
+            assert_eq!(
+                WwwAuthenticateHeaderContent::Bearer(WwwAuthenticateHeaderContentBearer {
+                    realm: realm.to_string(),
+                    service: Some(service.to_string()),
+                    scope: Some(scope.to_string()),
+                }),
+                content
+            );
         }
 
         Ok(())
@@ -375,10 +386,13 @@ mod tests {
             HeaderValue::from_str(&format!(r#"basic realm="{}""#, realm)).unwrap(),
             HeaderValue::from_str(&format!(r#"BASIC realm="{}""#, realm)).unwrap(),
             HeaderValue::from_str(&format!(r#"Basic Realm="{}""#, realm)).unwrap(),
-            HeaderValue::from_str(&format!(r#"Basic REALM="{}""#, realm)).unwrap()
-        ].iter() {
-            let content =
-                WwwAuthenticateHeaderContent::from_www_authentication_header(header_value.to_owned())?;
+            HeaderValue::from_str(&format!(r#"Basic REALM="{}""#, realm)).unwrap(),
+        ]
+        .iter()
+        {
+            let content = WwwAuthenticateHeaderContent::from_www_authentication_header(
+                header_value.to_owned(),
+            )?;
 
             assert_eq!(
                 WwwAuthenticateHeaderContent::Basic(WwwAuthenticateHeaderContentBasic {

--- a/src/v2/auth.rs
+++ b/src/v2/auth.rs
@@ -134,8 +134,7 @@ impl WwwAuthenticateHeaderContent {
             .name("method")
             .ok_or(WwwHeaderParseError::FieldMethodMissing)?
             .as_str()
-            .to_lowercase()
-            .to_string();
+            .to_lowercase();
 
         let serialized_content = {
             let serialized_captures = captures
@@ -144,7 +143,7 @@ impl WwwAuthenticateHeaderContent {
                     match (
                         capture
                             .name("key")
-                            .map(|n| n.as_str().to_lowercase().to_string()),
+                            .map(|n| n.as_str().to_lowercase()),
                         capture.name("value").map(|n| n.as_str().to_string()),
                     ) {
                         (Some(key), Some(value)) => Some(format!(


### PR DESCRIPTION
Closes #210 

I made the following changes to make the header parsing case-insensitive:

- adapted the Regex to match method and key case-insensitively. This also required some changes in the positioning of whitespace character classes (\s) to not break the group matching.
- convert the matched method to lowercase
- rename lowercase method to PascalCase when deserializing using serde annotation
- convert all matched keys to lowercase

I also extended the relevant tests to include some variations in upper/lowercase methods and keys.