### PR TITLE
Allow passing custom set of accepted types with optional weight

### DIFF
--- a/src/mediatypes.rs
+++ b/src/mediatypes.rs
@@ -6,7 +6,7 @@ use strum::EnumProperty;
 // For schema1 types, see https://docs.docker.com/registry/spec/manifest-v2-1/
 // For schema2 types, see https://docs.docker.com/registry/spec/manifest-v2-2/
 
-#[derive(EnumProperty, EnumString, Display, Debug, Hash, PartialEq)]
+#[derive(EnumProperty, EnumString, Display, Debug, Hash, PartialEq, Clone)]
 pub enum MediaTypes {
     /// Manifest, version 2 schema 1.
     #[strum(serialize = "application/vnd.docker.distribution.manifest.v1+json")]

--- a/src/v2/config.rs
+++ b/src/v2/config.rs
@@ -1,4 +1,4 @@
-use crate::v2::*;
+use crate::{mediatypes::MediaTypes, v2::*};
 
 /// Configuration for a `Client`.
 #[derive(Debug)]
@@ -9,6 +9,7 @@ pub struct Config {
     username: Option<String>,
     password: Option<String>,
     accept_invalid_certs: bool,
+    accepted_types: Option<Vec<(MediaTypes, Option<f64>)>>,
 }
 
 impl Config {
@@ -18,6 +19,7 @@ impl Config {
             index: "registry-1.docker.io".into(),
             insecure_registry: false,
             accept_invalid_certs: false,
+            accepted_types: None,
             user_agent: Some(crate::USER_AGENT.to_owned()),
             username: None,
             password: None,
@@ -39,6 +41,15 @@ impl Config {
     /// Set whether or not to accept invalid certificates.
     pub fn accept_invalid_certs(mut self, accept_invalid_certs: bool) -> Self {
         self.accept_invalid_certs = accept_invalid_certs;
+        self
+    }
+
+    /// Set custom Accept headers
+    pub fn accepted_types(
+        mut self,
+        accepted_types: Option<Vec<(MediaTypes, Option<f64>)>>,
+    ) -> Self {
+        self.accepted_types = accepted_types;
         self
     }
 
@@ -93,13 +104,33 @@ impl Config {
             .danger_accept_invalid_certs(self.accept_invalid_certs)
             .build()?;
 
+        let accepted_types = match self.accepted_types {
+            Some(a) => a,
+            None => match self.index == "gcr.io" || self.index.ends_with(".gcr.io") {
+                false => vec![
+                    // accept header types and their q value, as documented in
+                    // https://tools.ietf.org/html/rfc7231#section-5.3.2
+                    (MediaTypes::ManifestV2S2, Some(0.5)),
+                    (MediaTypes::ManifestV2S1Signed, Some(0.4)),
+                    // TODO(steveeJ): uncomment this when all the Manifest methods work for it
+                    // mediatypes::MediaTypes::ManifestList,
+                ],
+                // GCR incorrectly parses `q` parameters, so we use special Accept for it.
+                // Bug: https://issuetracker.google.com/issues/159827510.
+                // TODO: when bug is fixed, this workaround should be removed.
+                true => vec![
+                    (MediaTypes::ManifestV2S2, None),
+                    (MediaTypes::ManifestV2S1Signed, None),
+                ],
+            },
+        };
         let c = Client {
             base_url: base,
             credentials: creds,
-            index: self.index,
             user_agent: self.user_agent,
             auth: None,
             client,
+            accepted_types,
         };
         Ok(c)
     }

--- a/src/v2/manifest/mod.rs
+++ b/src/v2/manifest/mod.rs
@@ -33,7 +33,7 @@ impl Client {
     ) -> Result<(Manifest, Option<String>)> {
         let url = self.build_url(name, reference)?;
 
-        let accept_headers = build_accept_headers(&self.index);
+        let accept_headers = build_accept_headers(&self.accepted_types);
 
         let client_spare0 = self.clone();
 
@@ -107,7 +107,7 @@ impl Client {
     pub async fn get_manifestref(&self, name: &str, reference: &str) -> Result<Option<String>> {
         let url = self.build_url(name, reference)?;
 
-        let accept_headers = build_accept_headers(&self.index);
+        let accept_headers = build_accept_headers(&self.accepted_types);
 
         let res = self
             .build_reqwest(Method::HEAD, url)
@@ -249,31 +249,16 @@ fn evaluate_media_type(
     }
 }
 
-fn build_accept_headers(registry: &str) -> header::HeaderMap {
-    // GCR incorrectly parses `q` parameters, so we use special Accept for it.
-    // Bug: https://issuetracker.google.com/issues/159827510.
-    // TODO: when bug is fixed, this workaround should be removed.
-    let no_q = registry == "gcr.io" || registry.ends_with(".gcr.io");
-
-    let accepted_types = vec![
-        // accept header types and their q value, as documented in
-        // https://tools.ietf.org/html/rfc7231#section-5.3.2
-        (mediatypes::MediaTypes::ManifestV2S2, 0.5),
-        (mediatypes::MediaTypes::ManifestV2S1Signed, 0.4),
-        // TODO(steveeJ): uncomment this when all the Manifest methods work for it
-        // mediatypes::MediaTypes::ManifestList,
-    ];
-
+fn build_accept_headers(accepted_types: &[(MediaTypes, Option<f64>)]) -> header::HeaderMap {
     let accepted_types_string = accepted_types
-        .into_iter()
+        .iter()
         .map(|(ty, q)| {
             format!(
                 "{}{}",
                 ty,
-                if no_q {
-                    String::default()
-                } else {
-                    format!("; q={}", q)
+                match q {
+                    None => String::default(),
+                    Some(v) => format!("; q={}", v),
                 }
             )
         })
@@ -347,5 +332,51 @@ impl Manifest {
             // Manifest::ML(_) => TODO(steveeJ),
             _ => Err(ManifestError::ArchitectureNotSupported(format!("{:?}", self)).into()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_case::test_case;
+
+    use crate::v2::Client;
+
+    #[test_case("not-gcr.io" => "application/vnd.docker.distribution.manifest.v2+json; q=0.5,application/vnd.docker.distribution.manifest.v1+prettyjws; q=0.4"; "Not gcr registry")]
+    #[test_case("gcr.io" => "application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.v1+prettyjws"; "gcr.io")]
+    #[test_case("foobar.gcr.io" => "application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.v1+prettyjws"; "Custom gcr.io registry")]
+    fn gcr_io_accept_headers(registry: &str) -> String {
+        let client_builder = Client::configure().registry(&registry);
+        let client = client_builder.build().unwrap();
+        let header_map = build_accept_headers(&client.accepted_types);
+        header_map
+            .get(header::ACCEPT)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string()
+    }
+    #[test_case(None => "application/vnd.docker.distribution.manifest.v2+json; q=0.5,application/vnd.docker.distribution.manifest.v1+prettyjws; q=0.4"; "Default settings")]
+    #[test_case(Some(vec![
+        (MediaTypes::ManifestV2S2, Some(0.5)),
+        (MediaTypes::ManifestV2S1Signed, Some(0.2)),
+    ]) => "application/vnd.docker.distribution.manifest.v2+json; q=0.5,application/vnd.docker.distribution.manifest.v1+prettyjws; q=0.2"; "Custom accept types with weight")]
+    #[test_case(Some(vec![
+        (MediaTypes::ManifestV2S2, None),
+    ]) => "application/vnd.docker.distribution.manifest.v2+json"; "Custom accept types, no weight")]
+    fn custom_accept_headers(accept_headers: Option<Vec<(MediaTypes, Option<f64>)>>) -> String {
+        let registry = "https://example.com";
+
+        let client_builder = Client::configure()
+            .registry(&registry)
+            .accepted_types(accept_headers);
+        let client = client_builder.build().unwrap();
+        let header_map = build_accept_headers(&client.accepted_types);
+        header_map
+            .get(header::ACCEPT)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string()
     }
 }

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -28,6 +28,7 @@
 //! ```
 
 use crate::errors::*;
+use crate::mediatypes::MediaTypes;
 use futures::prelude::*;
 use reqwest::{Method, StatusCode, Url};
 
@@ -54,10 +55,10 @@ pub use self::content_digest::ContentDigestError;
 pub struct Client {
     base_url: String,
     credentials: Option<(String, String)>,
-    index: String,
     user_agent: Option<String>,
     auth: Option<auth::Auth>,
     client: reqwest::Client,
+    accepted_types: Vec<(MediaTypes, Option<f64>)>,
 }
 
 impl Client {


### PR DESCRIPTION
Some registries don't parse weight parameter correctly, some require custom parameter weights.

This commits allows passing custom set of accepted types (with optional weight) and moves GCR workaround from v2/manifest/mod.rs to config.rs.

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=2010497