### PR TITLE
Replace travis CI with Github Actions

### DIFF
--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -1,0 +1,113 @@
+# Based on https://github.com/actions-rs/meta/blob/master/recipes/quickstart.md
+
+on: [push, pull_request]
+
+name: Build & Test
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - beta
+          - 1.46.0  # MSRV
+        include:
+          - rust: nightly
+            experimental: true
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - beta
+          - 1.46.0  # MSRV
+        include:
+          - rust: nightly
+            experimental: true
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+      - name: Run cargo test (test-mock features)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --features test-mock
+
+      - name: Run cargo test (test-net-private)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --features test-net,test-net-private
+        env:
+          DKREG_QUAY_USER: ${{ secrets.DKREG_QUAY_USER }}
+          DKREG_QUAY_PASSWD: ${{ secrets.DKREG_QUAY_PASSWD }}
+
+  lints:
+    name: Lints
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - beta
+          - 1.46.0  # MSRV
+        include:
+          - rust: nightly
+            experimental: true
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+          components: rustfmt, clippy
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rust:
   - stable
   - beta
   - nightly
-  - 1.45.0
+  - 1.46.0
 cache: cargo
 matrix:
   allow_failures:

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -37,7 +37,10 @@ pub enum Error {
     LoginReturnedBadToken,
     #[error("www-authenticate header parse error")]
     Www(#[from] crate::v2::WwwHeaderParseError),
-    #[error("request failed with status {status} and body of size {len}: {}", String::from_utf8_lossy(&body))]
+    #[error(
+        "request failed with status {status} and body of size {len}: {}",
+        String::from_utf8_lossy(body)
+    )]
     Client {
         status: http::StatusCode,
         len: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,10 +46,9 @@ pub mod reference;
 pub mod render;
 pub mod v2;
 
-use errors::{Result, Error};
+use errors::{Error, Result};
 use std::collections::HashMap;
 use std::io::Read;
-
 
 /// Default User-Agent client identity.
 pub static USER_AGENT: &str = "camallo-dkregistry/0.0";

--- a/src/mediatypes.rs
+++ b/src/mediatypes.rs
@@ -14,13 +14,7 @@ pub enum MediaTypes {
     #[strum(props(Sub = "vnd.docker.distribution.manifest.v1+json"))]
     ManifestV2S1,
     /// Signed manifest, version 2 schema 1.
-    #[strum(
-        serialize = "application/vnd.docker.distribution.manifest.v1+prettyjws",
-        to_string = "application/vnd.docker.distribution.manifest.v1+prettyjws",
-
-        // TODO(steveeJ) find a generic way to handle this form
-        serialize = "application/vnd.docker.distribution.manifest.v1+prettyjws; charset=utf-8",
-    )]
+    #[strum(serialize = "application/vnd.docker.distribution.manifest.v1+prettyjws")]
     #[strum(props(Sub = "vnd.docker.distribution.manifest.v1+prettyjws"))]
     ManifestV2S1Signed,
     /// Manifest, version 2 schema 2.
@@ -62,16 +56,16 @@ impl MediaTypes {
                     }
                     ("vnd.docker.image.rootfs.diff.tar.gzip", _) => Ok(MediaTypes::ImageLayerTgz),
                     ("vnd.docker.container.image.v1", "json") => Ok(MediaTypes::ContainerConfigV1),
-                    _ => return Err(crate::Error::UnknownMimeType(mtype.clone())),
+                    _ => Err(crate::Error::UnknownMimeType(mtype.clone())),
                 }
             }
-            _ => return Err(crate::Error::UnknownMimeType(mtype.clone())),
+            _ => Err(crate::Error::UnknownMimeType(mtype.clone())),
         }
     }
     pub fn to_mime(&self) -> mime::Mime {
         match self {
             &MediaTypes::ApplicationJson => Ok(mime::APPLICATION_JSON),
-            ref m => {
+            m => {
                 if let Some(s) = m.get_str("Sub") {
                     ("application/".to_string() + s).parse()
                 } else {

--- a/src/mediatypes.rs
+++ b/src/mediatypes.rs
@@ -1,6 +1,6 @@
 //! Media-types for API objects.
 
-use crate::errors::{Result};
+use crate::errors::Result;
 use mime;
 use strum::EnumProperty;
 

--- a/src/mediatypes.rs
+++ b/src/mediatypes.rs
@@ -1,7 +1,6 @@
 //! Media-types for API objects.
 
 use crate::errors::Result;
-use mime;
 use strum::EnumProperty;
 
 // For schema1 types, see https://docs.docker.com/registry/spec/manifest-v2-1/

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -58,7 +58,7 @@ pub enum VersionParseError {
 impl str::FromStr for Version {
     type Err = VersionParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let v = match s.chars().nth(0) {
+        let v = match s.chars().next() {
             Some(':') => Version::Tag(s.trim_start_matches(':').to_string()),
             Some('@') => {
                 let r: Vec<&str> = s.trim_start_matches('@').splitn(2, ':').collect();
@@ -103,7 +103,6 @@ impl fmt::Display for Version {
 /// A registry image reference.
 #[derive(Clone, Debug, Default)]
 pub struct Reference {
-    has_schema: bool,
     raw_input: String,
     registry: String,
     repository: String,
@@ -115,7 +114,6 @@ impl Reference {
         let reg = registry.unwrap_or_else(|| DEFAULT_REGISTRY.to_string());
         let ver = version.unwrap_or_else(|| Version::Tag(DEFAULT_TAG.to_string()));
         Self {
-            has_schema: false,
             raw_input: "".into(),
             registry: reg,
             repository,
@@ -235,14 +233,14 @@ fn parse_url(input: &str) -> Result<Reference, ReferenceParseError> {
 
     // Handle images in default library namespace, that is:
     // `ubuntu` -> `library/ubuntu`
-    if components.is_empty() && &registry == DEFAULT_REGISTRY {
+    if components.is_empty() && registry == DEFAULT_REGISTRY {
         components.push_back("library".to_string());
     }
     components.push_back(image_name);
 
     // Check if all path components conform to the regex at
     // https://docs.docker.com/registry/spec/api/#overview.
-    const REGEX: &'static str = "^[a-z0-9]+(?:[._-][a-z0-9]+)*$";
+    const REGEX: &str = "^[a-z0-9]+(?:[._-][a-z0-9]+)*$";
     let path_re = regex::Regex::new(REGEX).expect("hardcoded regex is invalid");
     components.iter().try_for_each(|component| {
         if !path_re.is_match(component) {
@@ -265,7 +263,6 @@ fn parse_url(input: &str) -> Result<Reference, ReferenceParseError> {
     }
 
     Ok(Reference {
-        has_schema,
         raw_input: input.to_string(),
         registry,
         repository,

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -29,7 +29,6 @@
 // The `docker://` schema is not officially documented, but has a reference implementation:
 // https://github.com/docker/distribution/blob/v2.6.1/reference/reference.go
 
-use regex;
 use std::collections::VecDeque;
 use std::str::FromStr;
 use std::{fmt, str};

--- a/src/render.rs
+++ b/src/render.rs
@@ -5,7 +5,6 @@
 
 use libflate::gzip;
 use std::{fs, path};
-use tar;
 
 #[derive(Debug, thiserror::Error)]
 pub enum RenderError {

--- a/src/render.rs
+++ b/src/render.rs
@@ -12,7 +12,7 @@ pub enum RenderError {
     #[error("wrong target path {}: must be absolute path to existing directory", _0.display())]
     WrongTargetPath(path::PathBuf),
     #[error("io error")]
-    Io(#[from] std::io::Error)
+    Io(#[from] std::io::Error),
 }
 
 /// Unpack an ordered list of layers to a target directory.

--- a/src/v2/blobs.rs
+++ b/src/v2/blobs.rs
@@ -1,6 +1,5 @@
 use crate::errors::{Error, Result};
 use crate::v2::*;
-use reqwest;
 use reqwest::{Method, StatusCode};
 
 impl Client {

--- a/src/v2/catalog.rs
+++ b/src/v2/catalog.rs
@@ -23,7 +23,7 @@ impl v2::Client {
             };
             let ep = format!("{}/v2/_catalog{}", self.base_url.clone(), suffix);
 
-            reqwest::Url::parse(&ep).map_err(|err| crate::Error::from(err))
+            reqwest::Url::parse(&ep).map_err(crate::Error::from)
         };
 
         try_stream! {

--- a/src/v2/catalog.rs
+++ b/src/v2/catalog.rs
@@ -43,9 +43,7 @@ async fn fetch_catalog(req: RequestBuilder) -> Result<Catalog> {
     let status = r.status();
     trace!("Got status: {:?}", status);
     match status {
-        StatusCode::OK => r
-            .json::<Catalog>()
-            .await.map_err(Into::into),
+        StatusCode::OK => r.json::<Catalog>().await.map_err(Into::into),
         _ => Err(crate::Error::UnexpectedHttpStatus(status)),
     }
 }

--- a/src/v2/config.rs
+++ b/src/v2/config.rs
@@ -99,7 +99,7 @@ impl Config {
             index: self.index,
             user_agent: self.user_agent,
             auth: None,
-            client: client,
+            client,
         };
         Ok(c)
     }

--- a/src/v2/content_digest.rs
+++ b/src/v2/content_digest.rs
@@ -58,7 +58,7 @@ impl ContentDigest {
         if self != &layer_digest {
             return Err(ContentDigestError::Verify {
                 expected: self.clone(),
-                got: layer_digest.clone(),
+                got: layer_digest,
             });
         }
 

--- a/src/v2/manifest/mod.rs
+++ b/src/v2/manifest/mod.rs
@@ -1,7 +1,6 @@
 use crate::errors::{Error, Result};
 use crate::mediatypes;
 use crate::v2::*;
-use mime;
 use reqwest::{self, header, StatusCode, Url};
 use std::iter::FromIterator;
 use std::str::FromStr;

--- a/src/v2/manifest/mod.rs
+++ b/src/v2/manifest/mod.rs
@@ -101,7 +101,7 @@ impl Client {
             name,
             reference
         );
-        reqwest::Url::parse(&ep).map_err(|e| Error::from(e))
+        reqwest::Url::parse(&ep).map_err(Error::from)
     }
 
     /// Fetch content digest for a particular tag.
@@ -151,7 +151,7 @@ impl Client {
                 let m = mediatypes::MediaTypes::ManifestV2S2.to_mime();
                 vec![m]
             }
-            Some(ref v) => to_mimes(v),
+            Some(v) => to_mimes(v),
         };
 
         let mut accept_headers = header::HeaderMap::with_capacity(accept_types.len());
@@ -184,7 +184,7 @@ impl Client {
             | StatusCode::FOUND
             | StatusCode::OK => {
                 let media_type =
-                    evaluate_media_type(r.headers().get(header::CONTENT_TYPE), &r.url())?;
+                    evaluate_media_type(r.headers().get(header::CONTENT_TYPE), r.url())?;
                 trace!("Manifest media-type: {:?}", media_type);
                 Ok(Some(media_type))
             }

--- a/src/v2/tags.rs
+++ b/src/v2/tags.rs
@@ -35,7 +35,7 @@ impl Client {
 
                 link = match last {
                     None => break,
-                    Some(ref s) if s == "" => None,
+                    Some(ref s) if s.is_empty() => None,
                     s => s,
                 };
             }
@@ -110,14 +110,14 @@ fn parse_link(hdr: Option<&header::HeaderValue>) -> Option<String> {
     let uri = sval.trim_end_matches(">; rel=\"next\"");
     let query: Vec<&str> = uri.splitn(2, "next_page=").collect();
     let params = match query.get(1) {
-        Some(v) if *v != "" => v,
+        Some(v) if !v.is_empty() => v,
         _ => return None,
     };
 
     // Last item in current page (pagination parameter).
     let last: Vec<&str> = params.splitn(2, '&').collect();
     match last.get(0).cloned() {
-        Some(v) if v != "" => Some(v.to_string()),
+        Some(v) if !v.is_empty() => Some(v.to_string()),
         _ => None,
     }
 }


### PR DESCRIPTION
Travis CI is often failing, insecure and may be not be easy to retrigger. Github Actions are more flexible and integrate with Github nicely