### PR TITLE
github actions: move test-net-private tests to a separate suite

### DIFF
--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -67,6 +67,29 @@ jobs:
           command: test
           args: --features test-mock
 
+  test-net-private:
+    name: Test Suite (network-enabled tests)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - beta
+          - 1.46.0  # MSRV
+        include:
+          - rust: nightly
+            experimental: true
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+
       - name: Run cargo test (test-net-private)
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
test-net-private tests may be unstable, so we should not block on these