### PR TITLE
tests: tokio runtime no longer needs to be mutable

### DIFF
--- a/tests/mock/api_version.rs
+++ b/tests/mock/api_version.rs
@@ -16,7 +16,7 @@ fn test_version_check_status_ok() {
         .with_header(API_VERSION_K, API_VERSION_V)
         .create();
 
-    let mut runtime = Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
@@ -43,7 +43,7 @@ fn test_version_check_status_unauth() {
         .with_header(API_VERSION_K, API_VERSION_V)
         .create();
 
-    let mut runtime = Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
@@ -68,7 +68,7 @@ fn test_version_check_status_notfound() {
         .with_header(API_VERSION_K, API_VERSION_V)
         .create();
 
-    let mut runtime = Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
@@ -93,7 +93,7 @@ fn test_version_check_status_forbidden() {
         .with_header(API_VERSION_K, API_VERSION_V)
         .create();
 
-    let mut runtime = Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
@@ -115,7 +115,7 @@ fn test_version_check_noheader() {
     let addr = mockito::server_address().to_string();
     let _m = mock("GET", "/v2/").with_status(403).create();
 
-    let mut runtime = Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
@@ -140,7 +140,7 @@ fn test_version_check_trailing_slash() {
         .with_header(API_VERSION_K, API_VERSION_V)
         .create();
 
-    let mut runtime = Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)

--- a/tests/mock/base_client.rs
+++ b/tests/mock/base_client.rs
@@ -17,7 +17,7 @@ fn test_base_no_insecure() {
         .with_header(API_VERSION_K, API_VERSION_V)
         .create();
 
-    let mut runtime = Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(false)
@@ -45,7 +45,7 @@ fn test_base_useragent() {
         .with_header(API_VERSION_K, API_VERSION_V)
         .create();
 
-    let mut runtime = Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
@@ -73,7 +73,7 @@ fn test_base_custom_useragent() {
         .with_header(API_VERSION_K, API_VERSION_V)
         .create();
 
-    let mut runtime = Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)

--- a/tests/mock/blobs_download.rs
+++ b/tests/mock/blobs_download.rs
@@ -23,7 +23,7 @@ fn test_blobs_has_layer() {
         .with_header("Docker-Content-Digest", binary_digest)
         .create();
 
-    let mut runtime = Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
@@ -49,7 +49,7 @@ fn test_blobs_hasnot_layer() {
     let addr = mockito::server_address().to_string();
     let _m = mock("HEAD", ep.as_str()).with_status(404).create();
 
-    let mut runtime = Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
@@ -80,7 +80,7 @@ fn get_blobs_succeeds_with_consistent_layer() -> Fallible<()> {
         .with_body(blob)
         .create();
 
-    let mut runtime = Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
@@ -113,7 +113,7 @@ fn get_blobs_fails_with_inconsistent_layer() -> Fallible<()> {
         .with_body(blob2)
         .create();
 
-    let mut runtime = Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)

--- a/tests/mock/catalog.rs
+++ b/tests/mock/catalog.rs
@@ -18,7 +18,7 @@ fn test_catalog_simple() {
         .with_body(repos)
         .create();
 
-    let mut runtime = Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
@@ -59,7 +59,7 @@ fn test_catalog_paginate() {
         .with_body(repos_p2)
         .create();
 
-    let mut runtime = Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)

--- a/tests/mock/tags.rs
+++ b/tests/mock/tags.rs
@@ -20,7 +20,7 @@ fn test_tags_simple() {
         .with_body(tags)
         .create();
 
-    let mut runtime = Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
@@ -65,7 +65,7 @@ fn test_tags_paginate() {
         .with_body(tags_p2)
         .create();
 
-    let mut runtime = Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
@@ -100,7 +100,7 @@ fn test_tags_404() {
         .with_header("Content-Type", "application/json")
         .create();
 
-    let mut runtime = Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)
@@ -129,7 +129,7 @@ fn test_tags_missing_header() {
         .with_body(tags)
         .create();
 
-    let mut runtime = Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(&addr)
         .insecure_registry(true)

--- a/tests/net/docker_io/mod.rs
+++ b/tests/net/docker_io/mod.rs
@@ -31,7 +31,7 @@ fn test_dockerio_base() {
         None => return,
     };
 
-    let mut runtime = Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(REGISTRY)
         .insecure_registry(false)
@@ -48,7 +48,7 @@ fn test_dockerio_base() {
 
 #[test]
 fn test_dockerio_insecure() {
-    let mut runtime = Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(REGISTRY)
         .insecure_registry(true)
@@ -65,7 +65,7 @@ fn test_dockerio_insecure() {
 
 #[test]
 fn test_dockerio_anonymous_auth() {
-    let mut runtime = Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
     let image = "library/alpine";
     let version = "latest";
     let login_scope = format!("repository:{}:pull", image);

--- a/tests/net/gcr_io/mod.rs
+++ b/tests/net/gcr_io/mod.rs
@@ -33,7 +33,7 @@ fn test_gcrio_base() {
         None => return,
     };
 
-    let mut runtime = Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(REGISTRY)
         .insecure_registry(false)
@@ -50,7 +50,7 @@ fn test_gcrio_base() {
 
 #[test]
 fn test_gcrio_insecure() {
-    let mut runtime = Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(REGISTRY)
         .insecure_registry(true)
@@ -67,7 +67,7 @@ fn test_gcrio_insecure() {
 
 #[test]
 fn test_gcrio_get_tags() {
-    let mut runtime = Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(REGISTRY)
         .insecure_registry(false)
@@ -86,7 +86,7 @@ fn test_gcrio_get_tags() {
 
 #[test]
 fn test_gcrio_has_manifest() {
-    let mut runtime = Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(REGISTRY)
         .insecure_registry(false)
@@ -111,7 +111,7 @@ fn test_gcrio_has_manifest() {
 
 #[test]
 fn test_gcrio_get_manifest() {
-    let mut runtime = Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(REGISTRY)
         .insecure_registry(false)

--- a/tests/net/quay_io/mod.rs
+++ b/tests/net/quay_io/mod.rs
@@ -17,7 +17,7 @@ fn get_env() -> Option<(String, String)> {
 fn common_init(
     login_scope: Option<&str>,
 ) -> Option<(tokio::runtime::Runtime, dkregistry::v2::Client)> {
-    let mut runtime = Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
 
     let (user, password, login_scope) = if let Some(login_scope) = login_scope {
         match get_env() {
@@ -61,7 +61,7 @@ fn test_quayio_base() {
         None => return,
     };
 
-    let mut runtime = Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(REGISTRY)
         .insecure_registry(false)
@@ -79,7 +79,7 @@ fn test_quayio_base() {
 #[test]
 #[ignore]
 fn test_quayio_insecure() {
-    let mut runtime = Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(REGISTRY)
         .insecure_registry(true)
@@ -98,7 +98,7 @@ fn test_quayio_insecure() {
 #[test]
 fn test_quayio_auth_login() {
     let login_scope = "";
-    let (mut runtime, dclient) = common_init(Some(&login_scope)).unwrap();
+    let (runtime, dclient) = common_init(Some(&login_scope)).unwrap();
 
     let futlogin = dclient.is_auth();
     let res = runtime.block_on(futlogin).unwrap();
@@ -107,7 +107,7 @@ fn test_quayio_auth_login() {
 
 #[test]
 fn test_quayio_get_tags_simple() {
-    let mut runtime = Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(REGISTRY)
         .insecure_registry(false)
@@ -129,7 +129,7 @@ fn test_quayio_get_tags_simple() {
 
 #[test]
 fn test_quayio_get_tags_limit() {
-    let mut runtime = Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(REGISTRY)
         .insecure_registry(false)
@@ -151,7 +151,7 @@ fn test_quayio_get_tags_limit() {
 
 #[test]
 fn test_quayio_get_tags_pagination() {
-    let mut runtime = Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(REGISTRY)
         .insecure_registry(false)
@@ -176,7 +176,7 @@ fn test_quayio_get_tags_pagination() {
 fn test_quayio_auth_tags() {
     let image = "steveej/cincinnati-test";
     let login_scope = format!("repository:{}:pull", image);
-    let (mut runtime, dclient) = common_init(Some(&login_scope)).unwrap();
+    let (runtime, dclient) = common_init(Some(&login_scope)).unwrap();
 
     let tags = runtime
         .block_on(dclient.get_tags(image, None).collect::<Vec<_>>())
@@ -190,7 +190,7 @@ fn test_quayio_auth_tags() {
 
 #[test]
 fn test_quayio_has_manifest() {
-    let mut runtime = Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(REGISTRY)
         .insecure_registry(false)
@@ -213,7 +213,7 @@ fn test_quayio_auth_manifest() {
     let image = "steveej/cincinnati-test";
     let reference = "0.0.1";
     let login_scope = format!("repository:{}:pull", image);
-    let (mut runtime, dclient) = common_init(Some(&login_scope)).unwrap();
+    let (runtime, dclient) = common_init(Some(&login_scope)).unwrap();
 
     let fut_has_manifest = dclient.has_manifest(image, reference, None);
 
@@ -223,7 +223,7 @@ fn test_quayio_auth_manifest() {
 
 #[test]
 fn test_quayio_has_no_manifest() {
-    let mut runtime = Runtime::new().unwrap();
+    let runtime = Runtime::new().unwrap();
     let dclient = dkregistry::v2::Client::configure()
         .registry(REGISTRY)
         .insecure_registry(false)
@@ -247,7 +247,7 @@ fn test_quayio_auth_manifestref_missing() {
     let tag = "no-such-tag";
 
     let login_scope = format!("repository:{}:pull", image);
-    let (mut runtime, dclient) = common_init(Some(&login_scope)).unwrap();
+    let (runtime, dclient) = common_init(Some(&login_scope)).unwrap();
     let fut_actual = async { dclient.get_manifestref(image, tag).await };
     let actual = runtime.block_on(fut_actual);
     assert!(actual.is_err());
@@ -262,7 +262,7 @@ fn test_quayio_auth_manifestref() {
         String::from("sha256:cc1f79c6a6fc92982a10ced91bddeefb8fbd037a01ae106a64d0a7e79d0e4813");
 
     let login_scope = format!("repository:{}:pull", image);
-    let (mut runtime, dclient) = common_init(Some(&login_scope)).unwrap();
+    let (runtime, dclient) = common_init(Some(&login_scope)).unwrap();
     let fut_actual = async { dclient.get_manifestref(image, tag).await.unwrap() };
     let actual = runtime.block_on(fut_actual).unwrap();
     assert_eq!(actual, expected);
@@ -277,7 +277,7 @@ fn test_quayio_auth_layer_blob() {
     let layer0_len: usize = 198;
 
     let login_scope = format!("repository:{}:pull", image);
-    let (mut runtime, dclient) = common_init(Some(&login_scope)).unwrap();
+    let (runtime, dclient) = common_init(Some(&login_scope)).unwrap();
 
     let fut_layer0_blob = async {
         let digest = dclient

--- a/tests/reference.rs
+++ b/tests/reference.rs
@@ -10,7 +10,7 @@ fn valid_references() {
         input: &'a str,
         expected_repo: &'a str,
         expected_registry: &'a str,
-    };
+    }
 
     impl<'a> Default for Tcase<'a> {
         fn default() -> Tcase<'a> {


### PR DESCRIPTION
Since tokio 1.0 `runtime` in test can be immutable