### PR TITLE
github: run test-net-private via shell

### DIFF
--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -91,10 +91,7 @@ jobs:
           override: true
 
       - name: Run cargo test (test-net-private)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features test-net,test-net-private
+        run: cargo test --features test-net,test-net-private
         env:
           DKREG_QUAY_USER: ${{ secrets.DKREG_QUAY_USER }}
           DKREG_QUAY_PASSWD: ${{ secrets.DKREG_QUAY_PASSWD }}


### PR DESCRIPTION
`actions-rs/cargo@v1` ignores `env`, so we got 419 errors there as creds were not actually passed.
https://github.com/vrutkovs/dkregistry-rs/runs/4458280474