### PR TITLE
add support for ManifestList images

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ pub fn get_credentials<T: Read>(
     };
     let s = String::from_utf8(auth)?;
     let creds: Vec<&str> = s.splitn(2, ':').collect();
-    let up = match (creds.get(0), creds.get(1)) {
+    let up = match (creds.first(), creds.get(1)) {
         (Some(&""), Some(p)) => (None, Some(p.to_string())),
         (Some(u), Some(&"")) => (Some(u.to_string()), None),
         (Some(u), Some(p)) => (Some(u.to_string()), Some(p.to_string())),

--- a/src/mediatypes.rs
+++ b/src/mediatypes.rs
@@ -6,7 +6,7 @@ use strum::EnumProperty;
 // For schema1 types, see https://docs.docker.com/registry/spec/manifest-v2-1/
 // For schema2 types, see https://docs.docker.com/registry/spec/manifest-v2-2/
 
-#[derive(EnumProperty, EnumString, Display, Debug, Hash, PartialEq, Clone)]
+#[derive(EnumProperty, EnumString, Display, Debug, Hash, PartialEq, Eq, Clone)]
 pub enum MediaTypes {
     /// Manifest, version 2 schema 1.
     #[strum(serialize = "application/vnd.docker.distribution.manifest.v1+json")]

--- a/src/v2/config.rs
+++ b/src/v2/config.rs
@@ -112,8 +112,7 @@ impl Config {
                     // https://tools.ietf.org/html/rfc7231#section-5.3.2
                     (MediaTypes::ManifestV2S2, Some(0.5)),
                     (MediaTypes::ManifestV2S1Signed, Some(0.4)),
-                    // TODO(steveeJ): uncomment this when all the Manifest methods work for it
-                    // mediatypes::MediaTypes::ManifestList,
+                    (MediaTypes::ManifestList, Some(0.5)),
                 ],
                 // GCR incorrectly parses `q` parameters, so we use special Accept for it.
                 // Bug: https://issuetracker.google.com/issues/159827510.
@@ -121,6 +120,7 @@ impl Config {
                 true => vec![
                     (MediaTypes::ManifestV2S2, None),
                     (MediaTypes::ManifestV2S1Signed, None),
+                    (MediaTypes::ManifestList, None),
                 ],
             },
         };

--- a/src/v2/manifest/manifest_schema2.rs
+++ b/src/v2/manifest/manifest_schema2.rs
@@ -141,3 +141,27 @@ impl ManifestSchema2 {
         self.config_blob.architecture.to_owned()
     }
 }
+
+impl ManifestObj {
+    /// Get the architecture of the manifest object
+    pub fn architecture(&self) -> String {
+        self.platform.architecture.to_owned()
+    }
+
+    /// Returns the sha digest of the manifest object
+    pub fn digest(&self) -> String {
+        self.digest.to_owned()
+    }
+}
+
+impl ManifestList {
+    /// Get architecture of all the manifests
+    pub fn architectures(&self) -> Vec<String> {
+        self.manifests.iter().map(|mo| mo.architecture()).collect()
+    }
+
+    /// Get the digest for all the manifest images in the ManifestList
+    pub fn get_digests(&self) -> Vec<String> {
+        self.manifests.iter().map(|mo| mo.digest()).collect()
+    }
+}

--- a/src/v2/manifest/mod.rs
+++ b/src/v2/manifest/mod.rs
@@ -353,9 +353,9 @@ mod tests {
 
     use crate::v2::Client;
 
-    #[test_case("not-gcr.io" => "application/vnd.docker.distribution.manifest.v2+json; q=0.5,application/vnd.docker.distribution.manifest.v1+prettyjws; q=0.4"; "Not gcr registry")]
-    #[test_case("gcr.io" => "application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.v1+prettyjws"; "gcr.io")]
-    #[test_case("foobar.gcr.io" => "application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.v1+prettyjws"; "Custom gcr.io registry")]
+    #[test_case("not-gcr.io" => "application/vnd.docker.distribution.manifest.v2+json; q=0.5,application/vnd.docker.distribution.manifest.v1+prettyjws; q=0.4,application/vnd.docker.distribution.manifest.list.v2+json; q=0.5"; "Not gcr registry")]
+    #[test_case("gcr.io" => "application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.v1+prettyjws,application/vnd.docker.distribution.manifest.list.v2+json"; "gcr.io")]
+    #[test_case("foobar.gcr.io" => "application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.v1+prettyjws,application/vnd.docker.distribution.manifest.list.v2+json"; "Custom gcr.io registry")]
     fn gcr_io_accept_headers(registry: &str) -> String {
         let client_builder = Client::configure().registry(&registry);
         let client = client_builder.build().unwrap();
@@ -367,14 +367,16 @@ mod tests {
             .unwrap()
             .to_string()
     }
-    #[test_case(None => "application/vnd.docker.distribution.manifest.v2+json; q=0.5,application/vnd.docker.distribution.manifest.v1+prettyjws; q=0.4"; "Default settings")]
+    #[test_case(None => "application/vnd.docker.distribution.manifest.v2+json; q=0.5,application/vnd.docker.distribution.manifest.v1+prettyjws; q=0.4,application/vnd.docker.distribution.manifest.list.v2+json; q=0.5"; "Default settings")]
     #[test_case(Some(vec![
         (MediaTypes::ManifestV2S2, Some(0.5)),
         (MediaTypes::ManifestV2S1Signed, Some(0.2)),
-    ]) => "application/vnd.docker.distribution.manifest.v2+json; q=0.5,application/vnd.docker.distribution.manifest.v1+prettyjws; q=0.2"; "Custom accept types with weight")]
+        (MediaTypes::ManifestList, Some(0.5)),
+    ]) => "application/vnd.docker.distribution.manifest.v2+json; q=0.5,application/vnd.docker.distribution.manifest.v1+prettyjws; q=0.2,application/vnd.docker.distribution.manifest.list.v2+json; q=0.5"; "Custom accept types with weight")]
     #[test_case(Some(vec![
         (MediaTypes::ManifestV2S2, None),
-    ]) => "application/vnd.docker.distribution.manifest.v2+json"; "Custom accept types, no weight")]
+        (MediaTypes::ManifestList, None),
+    ]) => "application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.list.v2+json"; "Custom accept types, no weight")]
     fn custom_accept_headers(accept_headers: Option<Vec<(MediaTypes, Option<f64>)>>) -> String {
         let registry = "https://example.com";
 

--- a/src/v2/manifest/mod.rs
+++ b/src/v2/manifest/mod.rs
@@ -155,7 +155,7 @@ impl Client {
 
         let mut accept_headers = header::HeaderMap::with_capacity(accept_types.len());
         for accept_type in accept_types {
-            let header_value = header::HeaderValue::from_str(&accept_type.to_string())
+            let header_value = header::HeaderValue::from_str(accept_type.as_ref())
                 .expect("mime type is always valid header value");
             accept_headers.insert(header::ACCEPT, header_value);
         }

--- a/src/v2/tags.rs
+++ b/src/v2/tags.rs
@@ -116,7 +116,7 @@ fn parse_link(hdr: Option<&header::HeaderValue>) -> Option<String> {
 
     // Last item in current page (pagination parameter).
     let last: Vec<&str> = params.splitn(2, '&').collect();
-    match last.get(0).cloned() {
+    match last.first().cloned() {
         Some(v) if !v.is_empty() => Some(v.to_string()),
         _ => None,
     }


### PR DESCRIPTION
ManifestList images also known as fat-manifests are
collections of manifests for different arch/os.
this pr adds support for ManifestList images.

As manifest list images only contain digests of the
images contained in the manifest, the `layers_digests`
function returns the digest of all the images
contained in the ManifestList instead of individual
layers of the manifests.
The layers of a specific image from manifest list can
be obtained using the digest of the image from the
manifest list and getting it's manifest and manifestref
(get_manifest_and_ref()) and using this manifest of
the individual image to get the layers.