### PR TITLE
Bump MSRV to 1.58.0

### DIFF
--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -13,7 +13,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.46.0  # MSRV
+          - 1.58.0  # MSRV
         include:
           - rust: nightly
             experimental: true
@@ -41,7 +41,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.46.0  # MSRV
+          - 1.58.0  # MSRV
         include:
           - rust: nightly
             experimental: true
@@ -75,7 +75,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.46.0  # MSRV
+          - 1.58.0  # MSRV
         include:
           - rust: nightly
             experimental: true
@@ -104,7 +104,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.46.0  # MSRV
+          - 1.58.0  # MSRV
         include:
           - rust: nightly
             experimental: true


### PR DESCRIPTION
Run tests on Rust 1.58.0 at minimum