### PR TITLE
Special case *.k8s.io registries q value handling

### DIFF
--- a/src/v2/config.rs
+++ b/src/v2/config.rs
@@ -106,7 +106,10 @@ impl Config {
 
         let accepted_types = match self.accepted_types {
             Some(a) => a,
-            None => match self.index == "gcr.io" || self.index.ends_with(".gcr.io") {
+            None => match self.index == "gcr.io"
+                || self.index.ends_with(".gcr.io")
+                || self.index.ends_with(".k8s.io")
+            {
                 false => vec![
                     // accept header types and their q value, as documented in
                     // https://tools.ietf.org/html/rfc7231#section-5.3.2
@@ -117,6 +120,7 @@ impl Config {
                 // GCR incorrectly parses `q` parameters, so we use special Accept for it.
                 // Bug: https://issuetracker.google.com/issues/159827510.
                 // TODO: when bug is fixed, this workaround should be removed.
+                // *.k8s.io container registries use GCR and are similarly affected.
                 true => vec![
                     (MediaTypes::ManifestV2S2, None),
                     (MediaTypes::ManifestV2S1Signed, None),

--- a/src/v2/manifest/mod.rs
+++ b/src/v2/manifest/mod.rs
@@ -356,6 +356,7 @@ mod tests {
     #[test_case("not-gcr.io" => "application/vnd.docker.distribution.manifest.v2+json; q=0.5,application/vnd.docker.distribution.manifest.v1+prettyjws; q=0.4,application/vnd.docker.distribution.manifest.list.v2+json; q=0.5"; "Not gcr registry")]
     #[test_case("gcr.io" => "application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.v1+prettyjws,application/vnd.docker.distribution.manifest.list.v2+json"; "gcr.io")]
     #[test_case("foobar.gcr.io" => "application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.v1+prettyjws,application/vnd.docker.distribution.manifest.list.v2+json"; "Custom gcr.io registry")]
+    #[test_case("foobar.k8s.io" => "application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.v1+prettyjws,application/vnd.docker.distribution.manifest.list.v2+json"; "Custom k8s.io registry")]
     fn gcr_io_accept_headers(registry: &str) -> String {
         let client_builder = Client::configure().registry(&registry);
         let client = client_builder.build().unwrap();


### PR DESCRIPTION
Treat *.k8s.io registries like *.gcr.io, as the k8s registries are backed by GCR, and affected by the same q value handling bug.