### PR TITLE
Add support for OCI Image Index

### DIFF
--- a/src/mediatypes.rs
+++ b/src/mediatypes.rs
@@ -32,6 +32,10 @@ pub enum MediaTypes {
     #[strum(serialize = "application/vnd.docker.container.image.v1+json")]
     #[strum(props(Sub = "vnd.docker.container.image.v1+json"))]
     ContainerConfigV1,
+    /// OCI iamge index
+    #[strum(serialize = "application/vnd.oci.image.index.v1+json")]
+    #[strum(props(Sub = "vnd.oci.image.index.v1+json"))]
+    OCIImageIndexV1,
     /// Generic JSON
     #[strum(serialize = "application/json")]
     #[strum(props(Sub = "json"))]
@@ -55,6 +59,7 @@ impl MediaTypes {
                     }
                     ("vnd.docker.image.rootfs.diff.tar.gzip", _) => Ok(MediaTypes::ImageLayerTgz),
                     ("vnd.docker.container.image.v1", "json") => Ok(MediaTypes::ContainerConfigV1),
+                    ("vnd.oci.image.index.v1", "json") => Ok(MediaTypes::OCIImageIndexV1),
                     _ => Err(crate::Error::UnknownMimeType(mtype.clone())),
                 }
             }

--- a/src/v2/config.rs
+++ b/src/v2/config.rs
@@ -113,6 +113,7 @@ impl Config {
                     (MediaTypes::ManifestV2S2, Some(0.5)),
                     (MediaTypes::ManifestV2S1Signed, Some(0.4)),
                     (MediaTypes::ManifestList, Some(0.5)),
+                    (MediaTypes::OCIImageIndexV1, Some(0.5)),
                 ],
                 // GCR incorrectly parses `q` parameters, so we use special Accept for it.
                 // Bug: https://issuetracker.google.com/issues/159827510.

--- a/src/v2/manifest/mod.rs
+++ b/src/v2/manifest/mod.rs
@@ -85,7 +85,7 @@ impl Client {
                     content_digest,
                 ))
             }
-            mediatypes::MediaTypes::ManifestList => Ok((
+            mediatypes::MediaTypes::ManifestList | mediatypes::MediaTypes::OCIImageIndexV1 => Ok((
                 res.json::<ManifestList>().await.map(Manifest::ML)?,
                 content_digest,
             )),


### PR DESCRIPTION
To be honest, I don’t know enough about how Docker image manifests work, but from looking at the documentation it seems like OCI Image Index follows exactly the same format as Manifest Lists. So this makes us use that format for whenever we encounter the OCI Image Index MIME type.

This fixes #243 for me.