### PR TITLE
Increase MSRV to 1.70 due to colored crate dependency

### DIFF
--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -13,7 +13,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.65.0  # MSRV
+          - "1.70.0"  # MSRV
         include:
           - rust: nightly
             experimental: true
@@ -41,7 +41,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.65.0  # MSRV
+          - "1.70.0"  # MSRV
         include:
           - rust: nightly
             experimental: true
@@ -75,7 +75,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.65.0  # MSRV
+          - "1.70.0"  # MSRV
         include:
           - rust: nightly
             experimental: true
@@ -104,7 +104,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.65.0  # MSRV
+          - "1.70.0"  # MSRV
         include:
           - rust: nightly
             experimental: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "dkregistry"
+rust-version = "1.70.0"
 version = "0.5.1-alpha.0"
 authors = ["Luca Bruno <lucab@debian.org>", "Stefan Junker <sjunker@redhat.com>"]
 license = "MIT OR Apache-2.0"

--- a/src/v2/auth.rs
+++ b/src/v2/auth.rs
@@ -129,7 +129,7 @@ impl WwwAuthenticateHeaderContent {
         let captures = re.captures_iter(&header).collect::<Vec<_>>();
 
         let method = captures
-            .get(0)
+            .first()
             .ok_or(WwwHeaderParseError::InvalidValue)?
             .name("method")
             .ok_or(WwwHeaderParseError::FieldMethodMissing)?


### PR DESCRIPTION
The `colored` crate, a dependency of `mockito`, requires rust 1.70 or newer.

Also resolve a `clippy` warning.

Does not resolve the `HTTP 429 Too Many Requests` errors coming from the integration tests using `quay.io`