### PR TITLE
Bump reqwest from 0.11 to 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ strum = "0.23"
 strum_macros = "0.23"
 tar = "0.4"
 tokio = "1.0"
-reqwest = { version = "0.11", default-features = false, features = ["json", "stream"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "stream"] }
 sha2 = "^0.10.0"
 bytes = "1.1"
 pin-project = "1.0"


### PR DESCRIPTION
dkregistry-rs blocks cincinnati from bumping reqwest version:

```console
$ cincinnati git:(o-master) git --no-pager log --pretty=oneline -1
05fabafcd5ba15ed1a483716e5ae925d628433f7 (HEAD -> o-master, origin/master, origin/HEAD) Merge pull request #1007 from hongkailiu/ubi9-everywhere

$ cargo tree | grep dkr -A20
├── dkregistry v0.5.1-alpha.0 (https://github.com/camallo/dkregistry-rs.git?rev=0a3c99b7ede0c177a4389e0ffd9e566572633f8c#0a3c99b7)
│   ├── async-stream v0.3.6
│   │   ├── async-stream-impl v0.3.6 (proc-macro)
│   │   │   ├── proc-macro2 v1.0.89 (*)
│   │   │   ├── quote v1.0.37 (*)
│   │   │   └── syn v2.0.85 (*)
│   │   ├── futures-core v0.3.30
│   │   └── pin-project-lite v0.2.12
│   ├── base64 v0.13.1
│   ├── bytes v1.5.0
│   ├── futures v0.3.30 (*)
│   ├── libflate v1.2.0
│   │   ├── adler32 v1.2.0
│   │   ├── crc32fast v1.3.2 (*)
│   │   └── libflate_lz77 v1.2.0
│   │       └── rle-decode-fast v1.0.3
│   ├── log v0.4.20
│   ├── mime v0.3.17
│   ├── pin-project v1.1.0 (*)
│   ├── regex v1.11.1 (*)
│   ├── reqwest v0.11.22 (*)
```