### PR TITLE
Fix github actions

### DIFF
--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -1,5 +1,3 @@
-# Based on https://github.com/actions-rs/meta/blob/master/recipes/quickstart.md
-
 on: [push, pull_request]
 
 name: Build & Test
@@ -19,19 +17,17 @@ jobs:
             experimental: true
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
 
       - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
+        run: cargo check
 
   test:
     name: Test Suite
@@ -47,25 +43,20 @@ jobs:
             experimental: true
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Install toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
 
       - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+        run: cargo test
 
       - name: Run cargo test (test-mock features)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features test-mock
+        run: cargo test --features test-mock
 
   test-net-private:
     name: Test Suite (network-enabled tests)
@@ -83,8 +74,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Install toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           profile: minimal
           toolchain: ${{ matrix.rust }}
@@ -113,7 +104,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           profile: minimal
           toolchain: ${{ matrix.rust }}
@@ -121,13 +112,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+        run: cargo clippy -- -D warnings

--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -11,7 +11,7 @@ jobs:
         rust:
           - stable
           - beta
-          - "1.70.0"  # MSRV
+          - "1.84.1"  # MSRV
         include:
           - rust: nightly
             experimental: true
@@ -35,7 +35,7 @@ jobs:
         rust:
           - stable
           - beta
-          - "1.70.0"  # MSRV
+          - "1.84.1"  # MSRV
         include:
           - rust: nightly
             experimental: true
@@ -62,7 +62,7 @@ jobs:
         rust:
           - stable
           - beta
-          - "1.70.0"  # MSRV
+          - "1.84.1"  # MSRV
         include:
           - rust: nightly
             experimental: true
@@ -89,7 +89,7 @@ jobs:
         rust:
           - stable
           - beta
-          - "1.70.0"  # MSRV
+          - "1.84.1"  # MSRV
         include:
           - rust: nightly
             experimental: true

--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -22,9 +22,7 @@ jobs:
       - name: Install toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
 
       - name: Run cargo check
         run: cargo check
@@ -48,9 +46,7 @@ jobs:
       - name: Install toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
 
       - name: Run cargo test
         run: cargo test
@@ -77,9 +73,7 @@ jobs:
       - name: Install toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
 
       - name: Run cargo test (test-net-private)
         run: cargo test --features test-net,test-net-private
@@ -106,9 +100,7 @@ jobs:
       - name: Install toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
           components: rustfmt, clippy
 
       - name: Run cargo fmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dkregistry"
-rust-version = "1.70.0"
+rust-version = "1.84.1"
 version = "0.5.1-alpha.0"
 authors = ["Luca Bruno <lucab@debian.org>", "Stefan Junker <sjunker@redhat.com>"]
 license = "MIT OR Apache-2.0"

--- a/examples/checkregistry.rs
+++ b/examples/checkregistry.rs
@@ -12,7 +12,7 @@ async fn main() {
     let res = run(&registry).await;
 
     if let Err(e) = res {
-        println!("[{}] {}", registry, e);
+        println!("[{registry}] {e}");
         std::process::exit(1);
     };
 }
@@ -25,9 +25,9 @@ async fn run(host: &str) -> Result<bool, boxed::Box<dyn error::Error>> {
 
     let supported = dclient.is_v2_supported().await?;
     if supported {
-        println!("{} supports v2", host);
+        println!("{host} supports v2");
     } else {
-        println!("{} does NOT support v2", host);
+        println!("{host} does NOT support v2");
     }
     Ok(supported)
 }

--- a/examples/image-labels.rs
+++ b/examples/image-labels.rs
@@ -20,7 +20,7 @@ async fn main() {
     .unwrap();
     let registry = dkr_ref.registry();
 
-    println!("[{}] downloading image {}", registry, dkr_ref);
+    println!("[{registry}] downloading image {dkr_ref}");
 
     let mut user = None;
     let mut password = None;
@@ -32,23 +32,23 @@ async fn main() {
             user = user_pass.0;
             password = user_pass.1;
         } else {
-            println!("[{}] no credentials found in config.json", registry);
+            println!("[{registry}] no credentials found in config.json");
         }
     } else {
         user = env::var("DKREG_USER").ok();
         if user.is_none() {
-            println!("[{}] no $DKREG_USER for login user", registry);
+            println!("[{registry}] no $DKREG_USER for login user");
         }
         password = env::var("DKREG_PASSWD").ok();
         if password.is_none() {
-            println!("[{}] no $DKREG_PASSWD for login password", registry);
+            println!("[{registry}] no $DKREG_PASSWD for login password");
         }
     };
 
     let res = run(&dkr_ref, user, password).await;
 
     if let Err(e) = res {
-        println!("[{}] {}", registry, e);
+        println!("[{registry}] {e}");
         std::process::exit(1);
     };
 }
@@ -66,7 +66,7 @@ async fn run(
         .build()?;
 
     let image = dkr_ref.repository();
-    let login_scope = format!("repository:{}:pull", image);
+    let login_scope = format!("repository:{image}:pull");
     let version = dkr_ref.version();
 
     let dclient = client.authenticate(&[&login_scope]).await?;
@@ -74,7 +74,7 @@ async fn run(
 
     if let Manifest::S1Signed(s1s) = manifest {
         let labels = s1s.get_labels(0);
-        println!("got labels: {:#?}", labels);
+        println!("got labels: {labels:#?}");
     } else {
         println!("got no labels");
     }

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -35,13 +35,13 @@ async fn main() -> Result<(), boxed::Box<dyn error::Error>> {
         match std::env::var("IMAGE_OVERWRITE") {
             Ok(value) if value == "true" => {
                 std::fs::remove_dir_all(path)?;
-                eprintln!("{}, removing.", msg);
+                eprintln!("{msg}, removing.");
             }
-            _ => return Err(format!("{}, exiting.", msg).into()),
+            _ => return Err(format!("{msg}, exiting.").into()),
         }
     };
 
-    println!("[{}] downloading image {}:{}", registry, image, version);
+    println!("[{registry}] downloading image {image}:{version}");
 
     let mut user = None;
     let mut password = None;
@@ -53,23 +53,23 @@ async fn main() -> Result<(), boxed::Box<dyn error::Error>> {
             user = user_pass.0;
             password = user_pass.1;
         } else {
-            println!("[{}] no credentials found in config.json", registry);
+            println!("[{registry}] no credentials found in config.json");
         }
     } else {
         user = env::var("DKREG_USER").ok();
         if user.is_none() {
-            println!("[{}] no $DKREG_USER for login user", registry);
+            println!("[{registry}] no $DKREG_USER for login user");
         }
         password = env::var("DKREG_PASSWD").ok();
         if password.is_none() {
-            println!("[{}] no $DKREG_PASSWD for login password", registry);
+            println!("[{registry}] no $DKREG_PASSWD for login password");
         }
     };
 
-    let res = run(&registry, &image, &version, user, password, &path).await;
+    let res = run(&registry, &image, &version, user, password, path).await;
 
     if let Err(e) = res {
-        println!("[{}] {}", registry, e);
+        println!("[{registry}] {e}");
         std::process::exit(1);
     };
 
@@ -96,17 +96,17 @@ async fn run(
         .password(passwd)
         .build()?;
 
-    let login_scope = format!("repository:{}:pull", image);
+    let login_scope = format!("repository:{image}:pull");
 
     let dclient = client.authenticate(&[&login_scope]).await?;
-    let manifest = dclient.get_manifest(&image, &version).await?;
+    let manifest = dclient.get_manifest(image, version).await?;
     let layers_digests = manifest.layers_digests(None)?;
 
     println!("{} -> got {} layer(s)", &image, layers_digests.len(),);
 
     let blob_futures = layers_digests
         .iter()
-        .map(|layer_digest| dclient.get_blob(&image, &layer_digest))
+        .map(|layer_digest| dclient.get_blob(image, layer_digest))
         .collect::<Vec<_>>();
 
     let blobs = try_join_all(blob_futures).await?;
@@ -114,7 +114,7 @@ async fn run(
     println!("Downloaded {} layers", blobs.len());
 
     // TODO: use async io
-    std::fs::create_dir(&path).unwrap();
+    std::fs::create_dir(path).unwrap();
     let can_path = path.canonicalize().unwrap();
 
     println!("Unpacking layers to {:?}", &can_path);

--- a/examples/login.rs
+++ b/examples/login.rs
@@ -20,17 +20,17 @@ async fn main() {
 
     let user = std::env::var("DKREG_USER").ok();
     if user.is_none() {
-        println!("[{}] no $DKREG_USER for login user", registry);
+        println!("[{registry}] no $DKREG_USER for login user");
     }
     let password = std::env::var("DKREG_PASSWD").ok();
     if password.is_none() {
-        println!("[{}] no $DKREG_PASSWD for login password", registry);
+        println!("[{registry}] no $DKREG_PASSWD for login password");
     }
 
     let res = run(&registry, user, password, login_scope).await;
 
     if let Err(e) = res {
-        println!("[{}] {}", registry, e);
+        println!("[{registry}] {e}");
         std::process::exit(1);
     };
 }

--- a/examples/tags.rs
+++ b/examples/tags.rs
@@ -18,21 +18,21 @@ async fn main() {
         Some(x) => x,
         None => "library/debian".into(),
     };
-    println!("[{}] requesting tags for image {}", registry, image);
+    println!("[{registry}] requesting tags for image {image}");
 
     let user = std::env::var("DKREG_USER").ok();
     if user.is_none() {
-        println!("[{}] no $DKREG_USER for login user", registry);
+        println!("[{registry}] no $DKREG_USER for login user");
     }
     let password = std::env::var("DKREG_PASSWD").ok();
     if password.is_none() {
-        println!("[{}] no $DKREG_PASSWD for login password", registry);
+        println!("[{registry}] no $DKREG_PASSWD for login password");
     }
 
     let res = run(&registry, user, password, &image).await;
 
     if let Err(e) = res {
-        println!("[{}] {}", registry, e);
+        println!("[{registry}] {e}");
         std::process::exit(1);
     };
 }
@@ -55,18 +55,18 @@ async fn run(
         .password(passwd)
         .build()?;
 
-    let login_scope = format!("repository:{}:pull", image);
+    let login_scope = format!("repository:{image}:pull");
 
     let dclient = client.authenticate(&[&login_scope]).await?;
 
     dclient
-        .get_tags(&image, Some(7))
+        .get_tags(image, Some(7))
         .collect::<Vec<_>>()
         .await
         .into_iter()
         .map(Result::unwrap)
         .for_each(|tag| {
-            println!("{:?}", tag);
+            println!("{tag:?}");
         });
 
     Ok(())

--- a/examples/trace.rs
+++ b/examples/trace.rs
@@ -18,7 +18,7 @@ async fn main() {
     .unwrap();
     let registry = dkr_ref.registry();
 
-    println!("[{}] downloading image {}", registry, dkr_ref);
+    println!("[{registry}] downloading image {dkr_ref}");
 
     let mut user = None;
     let mut password = None;
@@ -30,23 +30,23 @@ async fn main() {
             user = user_pass.0;
             password = user_pass.1;
         } else {
-            println!("[{}] no credentials found in config.json", registry);
+            println!("[{registry}] no credentials found in config.json");
         }
     } else {
         user = env::var("DKREG_USER").ok();
         if user.is_none() {
-            println!("[{}] no $DKREG_USER for login user", registry);
+            println!("[{registry}] no $DKREG_USER for login user");
         }
         password = env::var("DKREG_PASSWD").ok();
         if password.is_none() {
-            println!("[{}] no $DKREG_PASSWD for login password", registry);
+            println!("[{registry}] no $DKREG_PASSWD for login password");
         }
     };
 
     let res = run(&dkr_ref, user, password).await;
 
     if let Err(e) = res {
-        println!("[{}] {:?}", registry, e);
+        println!("[{registry}] {e:?}");
         std::process::exit(1);
     };
 }
@@ -73,14 +73,14 @@ async fn run(
 
     let login_scope = "";
 
-    let dclient = client.authenticate(&[&login_scope]).await?;
+    let dclient = client.authenticate(&[login_scope]).await?;
     let manifest = dclient.get_manifest(&image, &version).await?;
 
     let layers_digests = manifest.layers_digests(None)?;
     println!("{} -> got {} layer(s)", &image, layers_digests.len(),);
 
     for layer_digest in &layers_digests {
-        let blob = dclient.get_blob(&image, &layer_digest).await?;
+        let blob = dclient.get_blob(&image, layer_digest).await?;
         println!("Layer {}, got {} bytes.\n", layer_digest, blob.len());
     }
 

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -85,7 +85,7 @@ impl fmt::Debug for Version {
             Version::Tag(ref s) => ":".to_string() + s,
             Version::Digest(ref t, ref d) => "@".to_string() + t + ":" + d,
         };
-        write!(f, "{}", v)
+        write!(f, "{v}")
     }
 }
 
@@ -95,7 +95,7 @@ impl fmt::Display for Version {
             Version::Tag(ref s) => s.to_string(),
             Version::Digest(ref t, ref d) => t.to_string() + ":" + d,
         };
-        write!(f, "{}", v)
+        write!(f, "{v}")
     }
 }
 

--- a/src/v2/auth.rs
+++ b/src/v2/auth.rs
@@ -172,9 +172,7 @@ impl WwwAuthenticateHeaderContent {
         )?;
 
         if !unsupported_keys.is_empty() {
-            warn!(
-                "skipping unrecognized keys in authentication header: {unsupported_keys:#?}"
-            );
+            warn!("skipping unrecognized keys in authentication header: {unsupported_keys:#?}");
         }
 
         Ok(content)

--- a/src/v2/auth.rs
+++ b/src/v2/auth.rs
@@ -38,7 +38,7 @@ impl BearerAuth {
         bearer_header_content: WwwAuthenticateHeaderContentBearer,
     ) -> Result<Self> {
         let auth_ep = bearer_header_content.auth_ep(scopes);
-        trace!("authenticate: token endpoint: {}", auth_ep);
+        trace!("authenticate: token endpoint: {auth_ep}");
 
         let url = reqwest::Url::parse(&auth_ep)?;
 
@@ -57,7 +57,7 @@ impl BearerAuth {
 
         let r = auth_req.send().await?;
         let status = r.status();
-        trace!("authenticate: got status {}", status);
+        trace!("authenticate: got status {status}");
         if status != StatusCode::OK {
             return Err(Error::UnexpectedHttpStatus(status));
         }
@@ -76,7 +76,7 @@ impl BearerAuth {
         let mut masked_token = bearer_auth.token.clone();
         masked_token.replace_range(mask_start..mask_end, &"*".repeat(mask_end - mask_start));
 
-        trace!("authenticate: got token: {:?}", masked_token);
+        trace!("authenticate: got token: {masked_token:?}");
 
         Ok(bearer_auth)
     }
@@ -173,8 +173,7 @@ impl WwwAuthenticateHeaderContent {
 
         if !unsupported_keys.is_empty() {
             warn!(
-                "skipping unrecognized keys in authentication header: {:#?}",
-                unsupported_keys
+                "skipping unrecognized keys in authentication header: {unsupported_keys:#?}"
             );
         }
 
@@ -195,7 +194,7 @@ impl WwwAuthenticateHeaderContentBearer {
         let service = self
             .service
             .as_ref()
-            .map(|sv| format!("?service={}", sv))
+            .map(|sv| format!("?service={sv}"))
             .unwrap_or_default();
 
         let scope = scopes
@@ -296,9 +295,9 @@ impl Client {
 
         let req = self.build_reqwest(Method::GET, url.clone());
 
-        trace!("Sending request to '{}'", url);
+        trace!("Sending request to '{url}'");
         let resp = req.send().await?;
-        trace!("GET '{:?}'", resp);
+        trace!("GET '{resp:?}'");
 
         let status = resp.status();
         match status {
@@ -322,28 +321,23 @@ mod tests {
 
         for header_value in [
             HeaderValue::from_str(&format!(
-                r#"Bearer realm="{}",service="{}",scope="{}""#,
-                realm, service, scope
+                r#"Bearer realm="{realm}",service="{service}",scope="{scope}""#
             ))
             .unwrap(),
             HeaderValue::from_str(&format!(
-                r#"bearer realm="{}",service="{}",scope="{}""#,
-                realm, service, scope
+                r#"bearer realm="{realm}",service="{service}",scope="{scope}""#
             ))
             .unwrap(),
             HeaderValue::from_str(&format!(
-                r#"BEARER realm="{}",service="{}",scope="{}""#,
-                realm, service, scope
+                r#"BEARER realm="{realm}",service="{service}",scope="{scope}""#
             ))
             .unwrap(),
             HeaderValue::from_str(&format!(
-                r#"Bearer Realm="{}",Service="{}",Scope="{}""#,
-                realm, service, scope
+                r#"Bearer Realm="{realm}",Service="{service}",Scope="{scope}""#
             ))
             .unwrap(),
             HeaderValue::from_str(&format!(
-                r#"Bearer REALM="{}",SERVICE="{}",SCOPE="{}""#,
-                realm, service, scope
+                r#"Bearer REALM="{realm}",SERVICE="{service}",SCOPE="{scope}""#
             ))
             .unwrap(),
         ]
@@ -379,11 +373,11 @@ mod tests {
         let realm = "Registry realm";
 
         for header_value in [
-            HeaderValue::from_str(&format!(r#"Basic realm="{}""#, realm)).unwrap(),
-            HeaderValue::from_str(&format!(r#"basic realm="{}""#, realm)).unwrap(),
-            HeaderValue::from_str(&format!(r#"BASIC realm="{}""#, realm)).unwrap(),
-            HeaderValue::from_str(&format!(r#"Basic Realm="{}""#, realm)).unwrap(),
-            HeaderValue::from_str(&format!(r#"Basic REALM="{}""#, realm)).unwrap(),
+            HeaderValue::from_str(&format!(r#"Basic realm="{realm}""#)).unwrap(),
+            HeaderValue::from_str(&format!(r#"basic realm="{realm}""#)).unwrap(),
+            HeaderValue::from_str(&format!(r#"BASIC realm="{realm}""#)).unwrap(),
+            HeaderValue::from_str(&format!(r#"Basic Realm="{realm}""#)).unwrap(),
+            HeaderValue::from_str(&format!(r#"Basic REALM="{realm}""#)).unwrap(),
         ]
         .iter()
         {

--- a/src/v2/blobs.rs
+++ b/src/v2/blobs.rs
@@ -39,7 +39,7 @@ impl Client {
         match resp.error_for_status_ref() {
             Ok(_) => {
                 if let Some(len) = resp.content_length() {
-                    trace!("Receiving a blob with {} bytes", len);
+                    trace!("Receiving a blob with {len} bytes");
                 } else {
                     trace!("Receiving a blob");
                 }
@@ -48,7 +48,7 @@ impl Client {
             Err(_) if status.is_client_error() => Err(Error::Client { status }),
             Err(_) if status.is_server_error() => Err(Error::Server { status }),
             Err(_) => {
-                error!("Received unexpected HTTP status '{}'", status);
+                error!("Received unexpected HTTP status '{status}'");
                 Err(Error::UnexpectedHttpStatus(status))
             }
         }

--- a/src/v2/catalog.rs
+++ b/src/v2/catalog.rs
@@ -17,7 +17,7 @@ impl v2::Client {
     ) -> impl Stream<Item = Result<String>> + 'a {
         let url = {
             let suffix = if let Some(n) = paginate {
-                format!("?n={}", n)
+                format!("?n={n}")
             } else {
                 "".to_string()
             };
@@ -41,7 +41,7 @@ impl v2::Client {
 async fn fetch_catalog(req: RequestBuilder) -> Result<Catalog> {
     let r = req.send().await?;
     let status = r.status();
-    trace!("Got status: {:?}", status);
+    trace!("Got status: {status:?}");
     match status {
         StatusCode::OK => r.json::<Catalog>().await.map_err(Into::into),
         _ => Err(crate::Error::UnexpectedHttpStatus(status)),

--- a/src/v2/content_digest.rs
+++ b/src/v2/content_digest.rs
@@ -105,7 +105,8 @@ mod tests {
     #[test]
     fn try_new_succeeds_with_correct_digest() -> Fallible<()> {
         {
-            let correct_digest = &"sha256:0000000000000000000000000000000000000000000000000000000000000000";
+            let correct_digest =
+                &"sha256:0000000000000000000000000000000000000000000000000000000000000000";
             ContentDigest::try_new(correct_digest)?;
         }
 

--- a/src/v2/content_digest.rs
+++ b/src/v2/content_digest.rs
@@ -104,9 +104,8 @@ mod tests {
 
     #[test]
     fn try_new_succeeds_with_correct_digest() -> Fallible<()> {
-        for correct_digest in
-            &["sha256:0000000000000000000000000000000000000000000000000000000000000000"]
         {
+            let correct_digest = &"sha256:0000000000000000000000000000000000000000000000000000000000000000";
             ContentDigest::try_new(correct_digest)?;
         }
 

--- a/src/v2/manifest/mod.rs
+++ b/src/v2/manifest/mod.rs
@@ -66,9 +66,7 @@ impl Client {
         let media_type = evaluate_media_type(header_content_type, &url)?;
 
         trace!(
-            "content-type: {:?}, media-type: {:?}",
-            header_content_type,
-            media_type
+            "content-type: {header_content_type:?}, media-type: {media_type:?}"
         );
 
         match media_type {
@@ -162,7 +160,7 @@ impl Client {
             accept_headers.insert(header::ACCEPT, header_value);
         }
 
-        trace!("HEAD {:?}", url);
+        trace!("HEAD {url:?}");
 
         let r = self
             .build_reqwest(Method::HEAD, url.clone())
@@ -186,7 +184,7 @@ impl Client {
             | StatusCode::OK => {
                 let media_type =
                     evaluate_media_type(r.headers().get(header::CONTENT_TYPE), r.url())?;
-                trace!("Manifest media-type: {:?}", media_type);
+                trace!("Manifest media-type: {media_type:?}");
                 Ok(Some(media_type))
             }
             StatusCode::NOT_FOUND => Ok(None),
@@ -236,7 +234,7 @@ fn evaluate_media_type(
                     .map_err(Into::into)
                 }
                 _ => {
-                    debug!("Received content-type '{}' from pulp-based registry. Feeling lucky and trying to parse it...", header_value);
+                    debug!("Received content-type '{header_value}' from pulp-based registry. Feeling lucky and trying to parse it...");
                     mediatypes::MediaTypes::from_str(header_value).map_err(Into::into)
                 }
             }
@@ -260,7 +258,7 @@ fn build_accept_headers(accepted_types: &[(MediaTypes, Option<f64>)]) -> header:
                 ty,
                 match q {
                     None => String::default(),
-                    Some(v) => format!("; q={}", v),
+                    Some(v) => format!("; q={v}"),
                 }
             )
         })
@@ -334,7 +332,7 @@ impl Manifest {
                 Ok(m.get_layers())
             }
             (Manifest::ML(m), _, _) => Ok(m.get_digests()),
-            _ => Err(ManifestError::LayerDigestsUnsupported(format!("{:?}", self)).into()),
+            _ => Err(ManifestError::LayerDigestsUnsupported(format!("{self:?}")).into()),
         }
     }
 
@@ -359,7 +357,7 @@ mod tests {
     #[test_case("gcr.io" => "application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.v1+prettyjws,application/vnd.docker.distribution.manifest.list.v2+json"; "gcr.io")]
     #[test_case("foobar.gcr.io" => "application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.v1+prettyjws,application/vnd.docker.distribution.manifest.list.v2+json"; "Custom gcr.io registry")]
     fn gcr_io_accept_headers(registry: &str) -> String {
-        let client_builder = Client::configure().registry(&registry);
+        let client_builder = Client::configure().registry(registry);
         let client = client_builder.build().unwrap();
         let header_map = build_accept_headers(&client.accepted_types);
         header_map
@@ -383,7 +381,7 @@ mod tests {
         let registry = "https://example.com";
 
         let client_builder = Client::configure()
-            .registry(&registry)
+            .registry(registry)
             .accepted_types(accept_headers);
         let client = client_builder.build().unwrap();
         let header_map = build_accept_headers(&client.accepted_types);

--- a/src/v2/manifest/mod.rs
+++ b/src/v2/manifest/mod.rs
@@ -65,9 +65,7 @@ impl Client {
         let header_content_type = headers.get(header::CONTENT_TYPE);
         let media_type = evaluate_media_type(header_content_type, &url)?;
 
-        trace!(
-            "content-type: {header_content_type:?}, media-type: {media_type:?}"
-        );
+        trace!("content-type: {header_content_type:?}, media-type: {media_type:?}");
 
         match media_type {
             mediatypes::MediaTypes::ManifestV2S1Signed => Ok((

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -93,7 +93,7 @@ impl Client {
         // GET request to bare v2 endpoint.
         let v2_endpoint = format!("{}/v2/", self.base_url);
         let request = reqwest::Url::parse(&v2_endpoint).map(|url| {
-            trace!("GET {:?}", url);
+            trace!("GET {url:?}");
             self.build_reqwest(Method::GET, url)
         })?;
 
@@ -103,7 +103,7 @@ impl Client {
             (StatusCode::OK, Some(x)) => Ok((x == api_version, true)),
             (StatusCode::UNAUTHORIZED, Some(x)) => Ok((x == api_version, false)),
             (s, v) => {
-                trace!("Got unexpected status {}, header version {:?}", s, v);
+                trace!("Got unexpected status {s}, header version {v:?}");
                 return Err(crate::Error::UnexpectedHttpStatus(s));
             }
         };

--- a/src/v2/tags.rs
+++ b/src/v2/tags.rs
@@ -49,9 +49,9 @@ impl Client {
         link: &Option<String>,
     ) -> Result<(TagsChunk, Option<String>)> {
         let url_paginated = match (paginate, link) {
-            (Some(p), None) => format!("{}?n={}", base_url, p),
-            (None, Some(l)) => format!("{}?{}", base_url, l),
-            (Some(_p), Some(l)) => format!("{}?{}", base_url, l),
+            (Some(p), None) => format!("{base_url}?n={p}"),
+            (None, Some(l)) => format!("{base_url}?{l}"),
+            (Some(_p), Some(l)) => format!("{base_url}?{l}"),
             _ => base_url.to_string(),
         };
         let url = Url::parse(&url_paginated)?;
@@ -66,7 +66,7 @@ impl Client {
         // ensure the CONTENT_TYPE header is application/json
         let ct_hdr = resp.headers().get(header::CONTENT_TYPE).cloned();
 
-        trace!("page url {:?}", ct_hdr);
+        trace!("page url {ct_hdr:?}");
 
         let ok = match ct_hdr {
             None => false,
@@ -75,12 +75,12 @@ impl Client {
         if !ok {
             // TODO:(steveeJ): Make this an error once Satellite
             // returns the content type correctly
-            debug!("get_tags: wrong content type '{:?}', ignoring...", ct_hdr);
+            debug!("get_tags: wrong content type '{ct_hdr:?}', ignoring...");
         }
 
         // extract the response body and parse the LINK header
         let next = parse_link(resp.headers().get(header::LINK));
-        trace!("next_page {:?}", next);
+        trace!("next_page {next:?}");
 
         let tags_chunk = resp.json::<TagsChunk>().await?;
         Ok((tags_chunk, next))
@@ -95,10 +95,7 @@ fn parse_link(hdr: Option<&header::HeaderValue>) -> Option<String> {
     // whether there is a a common library to do this, in the future.
 
     // Raw Header value bytes.
-    let hval = match hdr {
-        Some(v) => v,
-        None => return None,
-    };
+    let hval = hdr?;
 
     // Header value string.
     let sval = match hval.to_str() {

--- a/tests/reference.rs
+++ b/tests/reference.rs
@@ -91,7 +91,7 @@ fn valid_references() {
 
 #[test]
 fn invalid_references() {
-    let tcases = vec!["".into(), "L".repeat(128), ":justatag".into()];
+    let tcases = ["".into(), "L".repeat(128), ":justatag".into()];
 
     for t in tcases.iter() {
         let r = Reference::from_str(t);


### PR DESCRIPTION
https://github.com/actions-rs/meta is in the read-only mode. Google tells me https://github.com/actions-rust-lang/setup-rust-toolchain is popular.

I tested the workflow (with a new Rust version which will come with a separate pull https://github.com/camallo/dkregistry-rs/pull/268) with my own fork of this repo and it works [there](https://github.com/hongkailiu/dkregistry-rs/pull/2).

It removed the `profile` and `override` fields in the toolchain step.

The `profile` field is no longer supported and the `override` field
is default to `true` [1].

---

Update:
To fix the following error from https://github.com/camallo/dkregistry-rs/actions/runs/15149290276/job/42635397177?pr=267, we bump the Rust version in this PR:

```
  Downloaded adler32 v1.2.0
error: package `icu_normalizer_data v2.0.0` cannot be built because it requires rustc 1.82 or newer, while the currently active rustc version is 1.70.0
Either upgrade to rustc 1.82 or newer, or use
cargo update -p icu_normalizer_data@2.0.0 --precise ver
where `ver` is the latest version of `icu_normalizer_data` supporting rustc 1.70.0
```

[1]. https://github.com/actions-rust-lang/setup-rust-toolchain/blob/main/action.yml

/cc @PratikMahajan 