### PR TITLE
Fix net::docker_io::test_dockerio_anonymous_auth

### DIFF
--- a/tests/net/docker_io/mod.rs
+++ b/tests/net/docker_io/mod.rs
@@ -67,7 +67,7 @@ fn test_dockerio_insecure() {
 fn test_dockerio_anonymous_auth() {
     let runtime = Runtime::new().unwrap();
     let image = "library/alpine";
-    let version = "latest";
+    let version = "2.6";
     let login_scope = format!("repository:{}:pull", image);
     let scopes = vec![login_scope.as_str()];
     let dclient_future = dkregistry::v2::Client::configure()


### PR DESCRIPTION
The code does not work with the media type `application/vnd.oci.image.index.v1+json` that is returned for  `docker.io/library/alpine:latest`.
I think it is because the `latest` image uses the new format (not [a known type](https://github.com/camallo/dkregistry-rs/blob/ab205d97f071e186be858ff8c9c59d5f0782d8e5/src/mediatypes.rs#L10)).

So I tried with a very old image and it works.
<img width="1001" alt="Screenshot 2025-05-21 at 7 19 53 PM" src="https://github.com/user-attachments/assets/6cb86359-b1dc-4119-8841-9dfffa00dec4" />

Since cincinnati works with images from quay.io, I did not bother to handle the new media type, to keep the effort minimal and fix the broken tests.