### PR TITLE
Ignore Failing tests

### DIFF
--- a/tests/net/quay_io/mod.rs
+++ b/tests/net/quay_io/mod.rs
@@ -96,6 +96,7 @@ fn test_quayio_insecure() {
 
 #[cfg(feature = "test-net-private")]
 #[test]
+#[ignore]
 fn test_quayio_auth_login() {
     let login_scope = "";
     let (runtime, dclient) = common_init(Some(&login_scope)).unwrap();
@@ -173,6 +174,7 @@ fn test_quayio_get_tags_pagination() {
 
 #[cfg(feature = "test-net-private")]
 #[test]
+#[ignore]
 fn test_quayio_auth_tags() {
     let image = "steveej/cincinnati-test";
     let login_scope = format!("repository:{}:pull", image);
@@ -209,6 +211,7 @@ fn test_quayio_has_manifest() {
 
 #[cfg(feature = "test-net-private")]
 #[test]
+#[ignore]
 fn test_quayio_auth_manifest() {
     let image = "steveej/cincinnati-test";
     let reference = "0.0.1";
@@ -242,6 +245,7 @@ fn test_quayio_has_no_manifest() {
 
 #[cfg(feature = "test-net-private")]
 #[test]
+#[ignore]
 fn test_quayio_auth_manifestref_missing() {
     let image = "steveej/cincinnati-test";
     let tag = "no-such-tag";
@@ -255,6 +259,7 @@ fn test_quayio_auth_manifestref_missing() {
 
 #[cfg(feature = "test-net-private")]
 #[test]
+#[ignore]
 fn test_quayio_auth_manifestref() {
     let image = "steveej/cincinnati-test";
     let tag = "0.0.1";
@@ -270,6 +275,7 @@ fn test_quayio_auth_manifestref() {
 
 #[cfg(feature = "test-net-private")]
 #[test]
+#[ignore]
 fn test_quayio_auth_layer_blob() {
     let image = "steveej/cincinnati-test";
     let reference = "0.0.1";


### PR DESCRIPTION
From [the CI test](https://github.com/camallo/dkregistry-rs/actions/runs/15172773627/job/42666802553?pr=267):

```
failures:
    net::docker_io::test_dockerio_anonymous_auth
    net::quay_io::test_quayio_auth_layer_blob
    net::quay_io::test_quayio_auth_login
    net::quay_io::test_quayio_auth_manifest
    net::quay_io::test_quayio_auth_manifestref
    net::quay_io::test_quayio_auth_manifestref_missing
    net::quay_io::test_quayio_auth_tags

test result: FAILED. 16 passed; 7 failed; 1 ignored; 0 measured; 0 filtered out; finished in 1.39s
```
there are 7 tests failing in our CI job. `net::docker_io::test_dockerio_anonymous_auth` is fixed by https://github.com/camallo/dkregistry-rs/pull/269 and the remained six are ignored by this PR.

In my opinion, keeping failing tests in CI has no more value than reminding us of the work to fix them which is the goal of OTA-1552.

This PR will reduce the work of crossing checking the failures in CI for PR reviews, e.g, [this](https://github.com/camallo/dkregistry-rs/pull/269#issuecomment-2899598391). 

In addition, Green CI is always a nice thing to see.

This PR will be reverted as soon as OTA-1552 is complete.

/cc @PratikMahajan 


