### PR TITLE
Fix broken tests

### DIFF
--- a/tests/net/quay_io/mod.rs
+++ b/tests/net/quay_io/mod.rs
@@ -174,7 +174,7 @@ fn test_quayio_get_tags_pagination() {
 #[cfg(feature = "test-net-private")]
 #[test]
 fn test_quayio_auth_tags() {
-    let image = "steveej/cincinnati-test";
+    let image = "openshift-ota/cincinnati-test";
     let login_scope = format!("repository:{}:pull", image);
     let (runtime, dclient) = common_init(Some(&login_scope)).unwrap();
 
@@ -210,7 +210,7 @@ fn test_quayio_has_manifest() {
 #[cfg(feature = "test-net-private")]
 #[test]
 fn test_quayio_auth_manifest() {
-    let image = "steveej/cincinnati-test";
+    let image = "openshift-ota/cincinnati-test";
     let reference = "0.0.1";
     let login_scope = format!("repository:{}:pull", image);
     let (runtime, dclient) = common_init(Some(&login_scope)).unwrap();
@@ -243,7 +243,7 @@ fn test_quayio_has_no_manifest() {
 #[cfg(feature = "test-net-private")]
 #[test]
 fn test_quayio_auth_manifestref_missing() {
-    let image = "steveej/cincinnati-test";
+    let image = "openshift-ota/cincinnati-test";
     let tag = "no-such-tag";
 
     let login_scope = format!("repository:{}:pull", image);
@@ -256,10 +256,10 @@ fn test_quayio_auth_manifestref_missing() {
 #[cfg(feature = "test-net-private")]
 #[test]
 fn test_quayio_auth_manifestref() {
-    let image = "steveej/cincinnati-test";
+    let image = "openshift-ota/cincinnati-test";
     let tag = "0.0.1";
     let expected =
-        String::from("sha256:cc1f79c6a6fc92982a10ced91bddeefb8fbd037a01ae106a64d0a7e79d0e4813");
+        String::from("sha256:0a407c420a4a8b0239146d073562d8443f47a6d618e29453599e0610bf84844f");
 
     let login_scope = format!("repository:{}:pull", image);
     let (runtime, dclient) = common_init(Some(&login_scope)).unwrap();
@@ -271,10 +271,10 @@ fn test_quayio_auth_manifestref() {
 #[cfg(feature = "test-net-private")]
 #[test]
 fn test_quayio_auth_layer_blob() {
-    let image = "steveej/cincinnati-test";
+    let image = "openshift-ota/cincinnati-test";
     let reference = "0.0.1";
-    let layer0_sha = "sha256:ef11b765159341c08891fb84fa57d4a094903dd79059a2f8af9e1c3babda74e5";
-    let layer0_len: usize = 198;
+    let layer0_sha = "sha256:d97affeca500c97474d6b38339c44a33affed621dd61a961627228c057965aca";
+    let layer0_len: usize = 2485228;
 
     let login_scope = format!("repository:{}:pull", image);
     let (runtime, dclient) = common_init(Some(&login_scope)).unwrap();
@@ -286,7 +286,7 @@ fn test_quayio_auth_layer_blob() {
             .and_then(|manifest| {
                 let layers: Vec<String> = manifest.layers_digests(None)?;
                 let num_layers = layers.len();
-                assert!(num_layers == 1, "layers length: {}", num_layers);
+                assert!(num_layers == 2, "layers length: {}", num_layers);
                 let digest = layers[0].clone();
                 assert!(digest == layer0_sha, "layer0 digest: {}", digest);
                 Ok(digest)


### PR DESCRIPTION
https://issues.redhat.com/browse/OTA-1552

From [the CI test](https://github.com/camallo/dkregistry-rs/actions/runs/15172773627/job/42666802553?pr=267):

```
failures:
    net::docker_io::test_dockerio_anonymous_auth
    net::quay_io::test_quayio_auth_layer_blob
    net::quay_io::test_quayio_auth_login
    net::quay_io::test_quayio_auth_manifest
    net::quay_io::test_quayio_auth_manifestref
    net::quay_io::test_quayio_auth_manifestref_missing
    net::quay_io::test_quayio_auth_tags

test result: FAILED. 16 passed; 7 failed; 1 ignored; 0 measured; 0 filtered out; finished in 1.39s
```
there are 7 tests failing in our CI job. `net::docker_io::test_dockerio_anonymous_auth` is fixed by https://github.com/camallo/dkregistry-rs/pull/269 and the remained six are fixed by this PR.

---

The trick of getting an image for `application/vnd.docker.distribution.manifest.v1+prettyjws` which is required by `net::quay_io::test_quayio_auth_manifest`:

https://github.com/camallo/dkregistry-rs/blob/8e021d03859541c0f58f86f1f65aa986c6809222/tests/net/quay_io/mod.rs#L221

I tried with GPG sign with podman `podman push --sign-by hongkliu@redhat.com quay.io/openshift-ota/cincinnati-test:0.0.1 --authfile /tmp/hk.json` but it did not work.

So I noticed this PUBLIC image:

https://github.com/camallo/dkregistry-rs/blob/8e021d03859541c0f58f86f1f65aa986c6809222/tests/net/quay_io/mod.rs#L202-L207

and check with

```console
$ curl -I -sH 'Accept: application/vnd.docker.distribution.manifest.v1+prettyjws' https://quay.io/v2/coreos/alpine-sh/manifests/latest | grep content-type
content-type: application/vnd.docker.distribution.manifest.v1+prettyjws
```

Great. It has the expected type. Then I copied the image over and `net::quay_io::test_quayio_auth_manifest` becomes green.

```console
$ skopeo copy --dest-authfile /tmp/hk.json docker://quay.io/coreos/alpine-sh:latest docker://quay.io/openshift-ota/cincinnati-test:0.0.1
```

Other changes in the PR are the adjustments for the new image.

Hindsight is that it is very unlikely we have this type of images for OpenShift releases: neither `cosign` nor `gpg` signs images with that type. But maybe other projects relies on this. So keeping the type of image in the test intact might be a good idea.